### PR TITLE
Feature/suppress index

### DIFF
--- a/lib/ap/awesome_print.rb
+++ b/lib/ap/awesome_print.rb
@@ -14,6 +14,7 @@ class AwesomePrint
       :multiline => true,
       :plain     => false,
       :indent    => 4,
+      :index     => true,
       :color     => { 
         :array      => :white,
         :bigdecimal => :blue,
@@ -50,7 +51,11 @@ class AwesomePrint
     if @options[:multiline]
       width = (a.size - 1).to_s.size 
       data = a.inject([]) do |arr, item|
-        index = colorize("#{indent}[#{arr.size.to_s.rjust(width)}] ", :array)
+        index = if @options[:index]
+          colorize("#{indent}[#{arr.size.to_s.rjust(width)}] ", :array)
+        else
+          colorize(indent, :array)
+        end
         indented do
           arr << (index << awesome(item))
         end

--- a/spec/awesome_print_spec.rb
+++ b/spec/awesome_print_spec.rb
@@ -33,6 +33,23 @@ describe "AwesomePrint" do
 EOS
       end
 
+    it "plain multiline without index" do
+      @arr.ai(:plain => true, :index => false).should == <<-EOS.strip
+[
+    1,
+    :two,
+    "three",
+    [
+        nil,
+        [
+            true,
+            false
+        ]
+    ]
+]
+EOS
+      end
+
     it "plain multiline indented" do
       @arr.ai(:plain => true, :indent => 2).should == <<-EOS.strip
 [
@@ -44,6 +61,23 @@ EOS
     [1] [
       [0] true,
       [1] false
+    ]
+  ]
+]
+EOS
+    end
+
+    it "plain multiline indented without index" do
+      @arr.ai(:plain => true, :indent => 2, :index => false).should == <<-EOS.strip
+[
+  1,
+  :two,
+  "three",
+  [
+    nil,
+    [
+      true,
+      false
     ]
   ]
 ]
@@ -106,6 +140,16 @@ EOS
     [0] 1,
     [1] 2,
     [2] [...]
+]
+EOS
+    end
+
+    it "plain multiline without index" do
+      @arr.ai(:plain => true, :index => false).should == <<-EOS.strip
+[
+    1,
+    2,
+    [...]
 ]
 EOS
     end


### PR DESCRIPTION
I needed a way to suppress the array index in the output so I could dump the data structure and reuse it in a file. I added the option :index (set to true by default). If set to false, the array index is suppressed.

-Sean
