### PR TITLE
I added a flag to allow output of hashes to have their keys sorted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ rdoc
 pkg
 
 ## PROJECT::SPECIFIC
+.rvmrc

--- a/lib/ap/awesome_print.rb
+++ b/lib/ap/awesome_print.rb
@@ -75,7 +75,8 @@ class AwesomePrint
   def awesome_hash(h)
     return "{}" if h == {}
 
-    data = h.keys.map do |key|
+    keys = @options[:sorted_hash_keys] ? h.keys.sort { |a, b| a.to_s <=> b.to_s } : h.keys
+    data = keys.map do |key|
       plain_single_line do
         [ awesome(key), h[key] ]
       end

--- a/spec/awesome_print_spec.rb
+++ b/spec/awesome_print_spec.rb
@@ -264,6 +264,36 @@ EOS
   end
 
   #------------------------------------------------------------------------------
+  describe "Hash with several keys" do
+    before(:each) do
+      @hash = {"b" => "b", :a => "a", :z => "z", "alpha" => "alpha"}
+    end
+
+    it "plain multiline" do
+      @hash.ai(:plain => true).should == <<-EOS.strip
+{
+        "b" => "b",
+         :a => "a",
+         :z => "z",
+    "alpha" => "alpha"
+}
+EOS
+    end
+    
+    it "plain multiline with sorted keys" do
+      @hash.ai(:plain => true, :sorted_hash_keys => true).should == <<-EOS.strip
+{
+         :a => "a",
+    "alpha" => "alpha",
+        "b" => "b",
+         :z => "z"
+}
+EOS
+    end
+
+  end
+
+  #------------------------------------------------------------------------------
   describe "Negative options[:indent]" do
     before(:each) do
       @hash = { [0, 0, 255] => :yellow, :red => "rgb(255, 0, 0)", "magenta" => "rgb(255, 0, 255)" }


### PR DESCRIPTION
I needed this to easily compare, using diff, two large hashes. Made it really easy!

Love the gem!

Ed

P.S. Also added `.rvmrc` to `.gitignore`.
