### PR TITLE
AP Object monkey patch fix

### DIFF
--- a/lib/ap/core_ext/object.rb
+++ b/lib/ap/core_ext/object.rb
@@ -9,7 +9,7 @@ class Object #:nodoc:
 
     alias :"original_#{name}" :"#{name}"
     define_method name do |*args|
-      methods = self.send(:"original_#{name}", *args)
+      methods = Object.send(:"original_#{name}", *args)
       methods.instance_variable_set('@__awesome_methods__', self) # Evil?!
       methods.sort!
     end


### PR DESCRIPTION
AP's Object monkey patch causes net/telnet to fail. For example, the following raises from line 12 of AP/lib/core_ext/object.rb

require 'ap'
require 'net/telnet'

link = Net::Telnet::new("Host" => 'www.google.com', "Port" => 80, 'Telnetmode' => false, 'Prompt' => /.*/, 'Waittime' => 10.0, 'Binmode' => true)
link.cmd("GET / HTTP/1.1\r\n"){|c| puts c}

I posted a bug, and then decide to try to fix it. It turned out to be a very simple fix.

Regards
