### PR TITLE
Fix specs for MongoMapper mixin

### DIFF
--- a/lib/ap/mixin/mongo_mapper.rb
+++ b/lib/ap/mixin/mongo_mapper.rb
@@ -31,7 +31,7 @@ module AwesomePrintMongoMapper
   def awesome_mongo_mapper_instance(object)
     return object.inspect if !defined?(ActiveSupport::OrderedHash)
 
-    data = object.keys.keys.inject(ActiveSupport::OrderedHash.new) do |hash, name|
+    data = object.keys.keys.sort_by{|k| k}.inject(ActiveSupport::OrderedHash.new) do |hash, name|
       hash[name] = object[name]
       hash
     end
@@ -43,7 +43,7 @@ module AwesomePrintMongoMapper
   def awesome_mongo_mapper_class(object)
     return object.inspect if !defined?(ActiveSupport::OrderedHash) || !object.respond_to?(:keys)
 
-    data = object.keys.inject(ActiveSupport::OrderedHash.new) do |hash, c|
+    data = object.keys.sort_by{|k| k}.inject(ActiveSupport::OrderedHash.new) do |hash, c|
       hash[c.first] = (c.last.type || "undefined").to_s.underscore.intern
       hash
     end

--- a/spec/mongo_mapper_spec.rb
+++ b/spec/mongo_mapper_spec.rb
@@ -4,7 +4,7 @@ begin
   require "mongo_mapper"
   require "ap/mixin/mongo_mapper"
 
-  if defined?(MongoMapper)
+  if defined?(::MongoMapper)
     class User
       include MongoMapper::Document
 
@@ -23,8 +23,8 @@ begin
         str = <<-EOS.strip
 #<User:0x01234567> {
            "_id" => BSON::ObjectId('4d9183739a546f6806000001'),
-     "last_name" => "Capone",
-    "first_name" => "Al"
+    "first_name" => "Al",
+     "last_name" => "Capone"
 }
 EOS
         out.gsub!(/'([\w]+){23}'/, "'4d9183739a546f6806000001'")
@@ -36,8 +36,8 @@ EOS
         @ap.send(:awesome, User).should == <<-EOS.strip
 class User < Object {
            "_id" => :object_id,
-     "last_name" => :string,
-    "first_name" => :string
+    "first_name" => :string,
+     "last_name" => :string
 }
 EOS
       end


### PR DESCRIPTION
The specs for mongo_mapper have been fixed.  Running rspec on just mongo_mapper: 
<code>rspec spec/mongo_mapper_spec.rb</code> 
will have all the tests passing.

Running the tests in a suite will still cause both active_record and mongo_mapper test to fail.  This is due to namespacing issues and the way the mixins are loaded.  I'll investigate this a little further.
