### PR TITLE
Add check for when object.inspect is frozen

### DIFF
--- a/lib/ap/awesome_print.rb
+++ b/lib/ap/awesome_print.rb
@@ -157,7 +157,12 @@ class AwesomePrint
   # Catch all method to format an arbitrary object.
   #------------------------------------------------------------------------------
   def awesome_self(object, appear = {})
-    colorize(object.inspect.to_s << appear[:with].to_s, appear[:as] || declassify(object))
+    str_rep = object.inspect
+    str_rep = str_rep.dup          if str_rep.frozen?
+    str_rep = str_rep.to_s
+    str_rep << appear[:with].to_s
+
+    colorize(str_rep, appear[:as] || declassify(object))
   end
 
   # Dispatcher that detects data nesting and invokes object-aware formatter.


### PR DESCRIPTION
There was a very intermittent problem wherein when an object's inspect returned a frozen string, AP would blow up because #<< would attempt to modify it.

I added a call to #dup to reset the frozen status but only in cases where the string is in fact frozen, so the performance impact should be negligible.
