### PR TITLE
Fix for old versions of ActiveSupport

### DIFF
--- a/lib/awesome_print/ext/active_support.rb
+++ b/lib/awesome_print/ext/active_support.rb
@@ -14,7 +14,7 @@ module AwesomePrint
     def cast_with_active_support(object, type)
       cast = cast_without_active_support(object, type)
       if defined?(::ActiveSupport) && defined?(::HashWithIndifferentAccess)
-        if object.is_a?(::ActiveSupport::TimeWithZone) || object.is_a?(::Date)
+        if (defined?(::ActiveSupport::TimeWithZone) && object.is_a?(::ActiveSupport::TimeWithZone)) || object.is_a?(::Date)
           cast = :active_support_time
         elsif object.is_a?(::HashWithIndifferentAccess)
           cast = :hash_with_indifferent_access


### PR DESCRIPTION
Hi!

I'm working on old codebases without TimeWithZone defined.

This is a quick patch to ensure awesome_print still work there.

cheers,

-- Thibaut
