### PR TITLE
Patching awesome_bigdecimal to not have lossy precision.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    awesome_print (1.0.0)
+    awesome_print (1.0.2)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -189,12 +189,17 @@ module AwesomePrint
       colorize(ls.empty? ? d.inspect : "#{d.inspect}\n#{ls.chop}", :dir)
     end
 
-    # Format BigDecimal and Rational objects by convering them to Float.
+    # Format BigDecimal object.
     #------------------------------------------------------------------------------
     def awesome_bigdecimal(n)
-      colorize(n.to_f.inspect, :bigdecimal)
+      colorize(n.to_s("F"), :bigdecimal)
     end
-    alias :awesome_rational :awesome_bigdecimal
+    
+    # Format Rational object.
+    #------------------------------------------------------------------------------
+    def awesome_rational(n)
+      colorize(n.to_s, :rational)
+    end
 
     # Format a method.
     #------------------------------------------------------------------------------

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -43,6 +43,7 @@ module AwesomePrint
           :keyword    => :cyan,
           :method     => :purpleish,
           :nilclass   => :red,
+          :rational   => :blue,
           :string     => :yellowish,
           :struct     => :pale,
           :symbol     => :cyanish,

--- a/spec/formats_spec.rb
+++ b/spec/formats_spec.rb
@@ -479,14 +479,14 @@ EOS
 
   #------------------------------------------------------------------------------
   describe "BigDecimal and Rational" do
-    it "should present BigDecimal object as Float scalar" do
-      big = BigDecimal("2010.4")
-      big.ai(:plain => true).should == "2010.4"
+    it "should present BigDecimal object with arbitrary precision" do
+      big = BigDecimal("201020102010201020102010201020102010.4")
+      big.ai(:plain => true).should == "201020102010201020102010201020102010.4"
     end
 
-    it "should present Rational object as Float scalar" do
-      rat = Rational(2010, 2)
-      rat.ai(:plain => true).should == "1005.0"
+    it "should present Rational object with arbitrary precision" do
+      rat = Rational(201020102010201020102010201020102010, 2)
+      rat.ai(:plain => true).should == "100510051005100510051005100510051005/1"
     end
   end
 


### PR DESCRIPTION
The formatting of BigDecimal and Rational numbers by calling to_f messes up the precision of the numbers displayed, thus misleading the user as to the value of the number being shown. In example:

```
1.9.3p194 :001 > require "bigdecimal"
 => true 
1.9.3p194 :002 > ap BigDecimal.new("1234567890" * 10)
1.2345678901234567e+99
 => #<BigDecimal:7f8d7b858558,'0.1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 123456789E100',108(117)>
```

This patch addresses that issue by pre-formatting BigDecimal and Rationals with to_s before calling colorize to ensure that all precision is preserved in the output.
