### PR TITLE
fix for mongoid 3.x

### DIFF
--- a/lib/awesome_print/ext/mongoid.rb
+++ b/lib/awesome_print/ext/mongoid.rb
@@ -20,7 +20,7 @@ module AwesomePrint
           cast = :mongoid_class
         elsif object.class.ancestors.include?(::Mongoid::Document)
           cast = :mongoid_document
-        elsif object.is_a?(::BSON::ObjectId)
+        elsif defined?(::BSON) && object.is_a?(::BSON::ObjectId)
           cast = :mongoid_bson_id
         end
       end


### PR DESCRIPTION
quick fix for mongoid 3.x "NameError: uninitialized constant BSON"

```
>> ap 123
NameError: uninitialized constant BSON
        from /home/klemanski/.rvm/gems/jruby-1.6.7@global/gems/rake-0.9.2.2/lib/rake/ext/module.rb:36:in `const_missing'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/awesome_print-1.0.2/lib/awesome_print/ext/mongoid.rb:23:in `cast_with_mongoid'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/awesome_print-1.0.2/lib/awesome_print/formatter.rb:24:in `format'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/awesome_print-1.0.2/lib/awesome_print/inspector.rb:104:in `unnested'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/awesome_print-1.0.2/lib/awesome_print/inspector.rb:71:in `awesome'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/awesome_print-1.0.2/lib/awesome_print/core_ext/kernel.rb:10:in `ai'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/awesome_print-1.0.2/lib/awesome_print/core_ext/kernel.rb:15:in `ap'
        from (irb):2:in `evaluate'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/railties-3.2.5/lib/rails/commands/console.rb:47:in `start'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/railties-3.2.5/lib/rails/commands/console.rb:8:in `start'
        from /home/klemanski/.rvm/gems/jruby-1.6.7/gems/railties-3.2.5/lib/rails/commands.rb:41:in `(root)'
        from script/rails:6:in `require'
        from script/rails:6:in `(root)'
```
