### PR TITLE
Update lib/awesome_print/ext/mongoid.rb

### DIFF
--- a/lib/awesome_print/ext/mongoid.rb
+++ b/lib/awesome_print/ext/mongoid.rb
@@ -20,7 +20,7 @@ module AwesomePrint
           cast = :mongoid_class
         elsif object.class.ancestors.include?(::Mongoid::Document)
           cast = :mongoid_document
-        elsif object.is_a?(::BSON::ObjectId)
+        elsif defined?(::BSON) && object.is_a?(::BSON::ObjectId)
           cast = :mongoid_bson_id
         end
       end


### PR DESCRIPTION
Latest versions of Mongoid doesn't require BSON.

I guess it'd be good to check if the class is defined before using it.  At some point you may wish to remove this condition altogether (once you're no longer concerned with supporting older versions of Mongoid).
