### PR TITLE
Fixes undefined method `[]' for :@attributename:Symbol when using in puppet

### DIFF
--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -126,7 +126,7 @@ module AwesomePrint
     #------------------------------------------------------------------------------
     def awesome_object(o)
       vars = o.instance_variables.map do |var|
-        property = var[1..-1].to_sym
+        property = var.to_s[1..-1].to_sym
         accessor = if o.respond_to?(:"#{property}=")
           o.respond_to?(property) ? :accessor : :writer
         else


### PR DESCRIPTION
On my centos machine (ruby 1.8.7 (2011-06-30 patchlevel 352)), the awesome_object method fails using it from within a puppet function.

```
Error: undefined method `[]' for :@content:Symbol at /etc/puppet/environments/production/modules/upstream/infrastructure/manifests/init.pp:10 on node puppetca01.virtual.vstone.org
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/formatter.rb:130:in `awesome_object'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/formatter.rb:128:in `map'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/formatter.rb:128:in `awesome_object'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/formatter.rb:65:in `awesome_self'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/formatter.rb:28:in `format'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/inspector.rb:137:in `unnested'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/inspector.rb:104:in `awesome'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/core_ext/kernel.rb:10:in `ai'
/usr/lib/ruby/gems/1.8/gems/awesome_print-1.1.0/lib/awesome_print/core_ext/kernel.rb:15:in `ap'

```

It looks like var[1..-1] does not work properly since var is a Symbol. This is due to some monkeypatching done by puppet:
https://github.com/puppetlabs/puppet/blob/master/lib/puppet/util/monkey_patches.rb#L233

Although this might be a puppet flaw, its an easy enough fix here (as opposed to waiting 3 years with the puppet codebase ;))
