### PR TITLE
Ensure that Moped and Moped::BSON is defined before testing against Mope...

### DIFF
--- a/lib/awesome_print/ext/mongoid.rb
+++ b/lib/awesome_print/ext/mongoid.rb
@@ -20,7 +20,7 @@ module AwesomePrint
           cast = :mongoid_class
         elsif object.class.ancestors.include?(::Mongoid::Document)
           cast = :mongoid_document
-        elsif (defined?(::BSON) && object.is_a?(::BSON::ObjectId)) || (defined?(::Moped) && object.is_a?(::Moped::BSON::ObjectId))
+        elsif (defined?(::BSON) && object.is_a?(::BSON::ObjectId)) || (defined?(::Moped) && defined?(::Moped::BSON) && object.is_a?(::Moped::BSON::ObjectId))
           cast = :mongoid_bson_id
         end
       end


### PR DESCRIPTION
...d::BSON::ObjectID

In my environment we had an issue where ap was causing sidekiq to blow up because apparently our moped is not eager loading Moped::BSON.  Moped was present.
