### PR TITLE
awesome_file works with closed file

### DIFF
--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -197,7 +197,7 @@ module AwesomePrint
     #------------------------------------------------------------------------------
     def awesome_file(f)
       ls = `ls -adlF #{f.path.shellescape}`
-      colorize(ls.empty? ? f.inspect, "#{f.inspect}\n#{ls.chop}", :file)
+      colorize(ls.empty? ? f.inspect : "#{f.inspect}\n#{ls.chop}", :file)
     end
 
     # Format Dir object.


### PR DESCRIPTION
Test case: 
`echo "a\nb\nc" > /tmp/test`
`irb`
irb > `File.open("/tmp/test") { |file| file.each_line { |line| puts "Got #{ line.dump }" } }`

Log:
Got "a\nb\nc\n"
IOError: closed stream
    from /Users/user/.rvm/gems/ruby-2.1.0-preview1/gems/awesome_print-1.2.0/lib/awesome_print/formatter.rb:199:in `directory?'

Root cause: `File.directory?(f)` asks closed f(ile)

It looks like it isn't necessary to do this check. If `ls -d` runs for file, '-d' - is ignored
