### PR TITLE
Fix printing abstract classes in ActiveRecord 3

### DIFF
--- a/lib/awesome_print/ext/active_record.rb
+++ b/lib/awesome_print/ext/active_record.rb
@@ -56,6 +56,7 @@ module AwesomePrint
     #------------------------------------------------------------------------------
     def awesome_active_record_class(object)
       return object.inspect if !defined?(::ActiveSupport::OrderedHash) || !object.respond_to?(:columns) || object.to_s == "ActiveRecord::Base"
+      return awesome_class(object) if object.respond_to?(:abstract_class?) && object.abstract_class?
 
       data = object.columns.inject(::ActiveSupport::OrderedHash.new) do |hash, c|
         hash[c.name.to_sym] = c.type

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -49,6 +49,10 @@ begin
       end
     end
 
+    class AbstractClass < ActiveRecord::Base
+      self.abstract_class = true
+    end
+
     describe "AwesomePrint/ActiveRecord" do
       before do
         stub_dotfile!
@@ -391,6 +395,10 @@ EOS
 
         it "should print ActiveRecord::Base objects (ex. ancestors)" do
           lambda { @ap.send(:awesome, User.ancestors) }.should_not raise_error
+        end
+
+        it "should print an abstract class" do
+          @ap.send(:awesome, AbstractClass).should == "AbstractClass(abstract) < ActiveRecord::Base"
         end
       end
 


### PR DESCRIPTION
I noticed that AwesomePrint raises an error when you try to use it with an abstract class using ActiveRecord 3. This happens because `ActiveRecord::Base.columns` tries to inspect the DB columns, and an abstract class has none.

For example:

``` ruby
class Blah < ActiveRecord::Base
  self.abstract_class = true
end
```

Then in the Rails console:

```
2.0.0-p247> ap Blah
ActiveRecord::StatementInvalid: Could not find table ''
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activerecord-3.2.16/lib/active_record/connection_adapters/sqlite_adapter.rb:472:in `table_structure'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activerecord-3.2.16/lib/active_record/connection_adapters/sqlite_adapter.rb:346:in `columns'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activerecord-3.2.16/lib/active_record/connection_adapters/schema_cache.rb:12:in `block in initialize'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activerecord-3.2.16/lib/active_record/model_schema.rb:229:in `yield'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activerecord-3.2.16/lib/active_record/model_schema.rb:229:in `columns'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/awesome_print-1.2.0/lib/awesome_print/ext/active_record.rb:60:in `awesome_active_record_class'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/awesome_print-1.2.0/lib/awesome_print/formatter.rb:26:in `format'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/awesome_print-1.2.0/lib/awesome_print/inspector.rb:137:in `unnested'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/awesome_print-1.2.0/lib/awesome_print/inspector.rb:104:in `awesome'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/awesome_print-1.2.0/lib/awesome_print/core_ext/kernel.rb:10:in `ai'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/awesome_print-1.2.0/lib/awesome_print/core_ext/kernel.rb:20:in `ap'
  from (irb):1
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/railties-3.2.16/lib/rails/commands/console.rb:47:in `start'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/railties-3.2.16/lib/rails/commands/console.rb:8:in `start'
  from /Users/priddle/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/railties-3.2.16/lib/rails/commands.rb:41:in `<top (required)>'
  from script/rails:6:in `require'
  from script/rails:6:in `<main>'ap_test (2.0.0-p247) >
```

This has been fixed in ActiveRecord 4:

```
2.0.0-p247> ap Blah
DEPRECATION WARNING: call columns with a table name!. (called from irb_binding at (irb):1)
class Blah < ActiveRecord::Base {}
=> nil
```

This patch tweaks awesome_print to work around the issue with ActiveRecord 3 by using `awesome_class` if the model is an abstract class. The new output:

```
2.0.0-p247> ap Blah
Blah(abstract) < ActiveRecord::Base
```
