### PR TITLE
Lazy-load ActionView via ActiveSupport.on_load hook

### DIFF
--- a/lib/awesome_print.rb
+++ b/lib/awesome_print.rb
@@ -25,7 +25,11 @@ unless defined?(AwesomePrint::Inspector)
   #
   # Load remaining extensions.
   #
-  require File.dirname(__FILE__) + "/awesome_print/ext/action_view"    if defined?(ActionView::Base)
+  if defined?(ActiveSupport)
+    ActiveSupport.on_load(:action_view) do
+      require File.dirname(__FILE__) + "/awesome_print/ext/action_view"
+    end
+  end
   require File.dirname(__FILE__) + "/awesome_print/ext/mongo_mapper"   if defined?(MongoMapper)
   require File.dirname(__FILE__) + "/awesome_print/ext/mongoid"        if defined?(Mongoid)
   require File.dirname(__FILE__) + "/awesome_print/ext/nokogiri"       if defined?(Nokogiri)


### PR DESCRIPTION
Before this change, if awesome_print gem was bundled onto a Rails app, [this line](https://github.com/michaeldv/awesome_print/blob/f36e788/lib/awesome_print.rb#L28) triggers all the ActionView related initialization process even in situations that ActionView is not actually needed (e.g. booting up the Rails console, executing a model test, running a Rake task, etc.) because referencing ActionView::Base constant immediately kicks :action_view load_hooks.

With this change,
1. In case of a non-Rails app that does not use ActiveSupport
   Nothing happens.
2. An application that uses ActiveSupport but does not use ActionView
   The registered :action_view on_load hook will never be executed.
3. An application that uses ActionView but doesn't have ActiveSupport constant
   This never happens. actionview gem depends on activesupport gem.
4. A Rails app with ActionView
   :action_view on_load hook will just be executed only when ActionView::Base is loaded by someone.
