### PR TITLE
Fix new ActiveRecord::Relation instance presentation for Rails>=4

### DIFF
--- a/lib/awesome_print/ext/active_record.rb
+++ b/lib/awesome_print/ext/active_record.rb
@@ -21,7 +21,7 @@ module AwesomePrint
         cast = :active_record_instance
       elsif object.is_a?(Class) && object.ancestors.include?(::ActiveRecord::Base)
         cast = :active_record_class
-      elsif type == :activerecord_relation
+      elsif type == :activerecord_relation || object.class.ancestors.include?(::ActiveRecord::Relation)
         cast = :array
       end
       cast


### PR DESCRIPTION
This problem is described in StackOverflow thread.
http://stackoverflow.com/questions/23290040/why-doesnt-awesome-print-work-on-some-rails-collection-objects and also issued in #159.

_Tl;dr_
The class of Relation object in Rails>=4 is like:

> Post.all.class 
> => ActiveRecord::Relation::ActiveRecord_Relation_Post

This is a clear patch to solve this problem.
