### PR TITLE
Use the last RSpec 2

### DIFF
--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.executables   = []
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec",  ">= 2.6.0"
+  s.add_development_dependency "rspec",  "~> 2.0"
   s.add_development_dependency "fakefs", ">= 0.2.1"
 end


### PR DESCRIPTION
With the `>=` operator the RSpec installed is the 3.x.x wich breaks and
deprecate some APIs, this way generating broken specs.

Now we are using the last RSpec 2 using the `~>` operator.
