### PR TITLE
ActiveSupport check more accurate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.6.2 (unreleased)
   - Improves spec performance and simplicity (Mauro George)
   - Handle objects that have a custom #to_hash method (Elliot Shank)
+  - Make ActiveSupport check more accurate (Karim Kiatlottiavi)
 
 1.6.1
   - Fixes specs on all rails dependencies (Mauro George)
@@ -116,4 +117,3 @@
 
 0.1.0
   - Initial Release.
-

--- a/lib/awesome_print.rb
+++ b/lib/awesome_print.rb
@@ -25,7 +25,7 @@ unless defined?(AwesomePrint::Inspector)
   #
   # Load remaining extensions.
   #
-  if defined?(ActiveSupport)
+  if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
     ActiveSupport.on_load(:action_view) do
       require File.dirname(__FILE__) + "/awesome_print/ext/action_view"
     end


### PR DESCRIPTION
Due some gems (ex. mail) define own ActiveSupport dummy class, we need more accurate check real ActiveSupport class existing.