### PR TITLE
ActiveRecord awesome #joins: now shows the #select'ed columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master (unreleased)
+  - ActiveRecord: #joins now show the columns #select'ed [@adrianomitre] - [#211]
   - Handles NoMethodError for IRB implicit `ai` [@jtnegrotto] - [#212]
 
 ## 1.7.0

--- a/lib/awesome_print/ext/active_record.rb
+++ b/lib/awesome_print/ext/active_record.rb
@@ -42,13 +42,17 @@ module AwesomePrint
       return object.inspect if !defined?(::ActiveSupport::OrderedHash)
       return awesome_object(object) if @options[:raw]
 
-      data = object.class.column_names.inject(::ActiveSupport::OrderedHash.new) do |hash, name|
-        if object.has_attribute?(name) || object.new_record?
-          value = object.respond_to?(name) ? object.send(name) : object.read_attribute(name)
-          hash[name.to_sym] = value
-        end
-        hash
-      end
+      data = if object.class.column_names != object.attributes.keys
+               object.attributes
+             else
+               object.class.column_names.inject(::ActiveSupport::OrderedHash.new) do |hash, name|
+                 if object.has_attribute?(name) || object.new_record?
+                   value = object.respond_to?(name) ? object.send(name) : object.read_attribute(name)
+                   hash[name.to_sym] = value
+                 end
+                 hash
+               end
+             end
       "#{object} " << awesome_hash(data)
     end
 

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -18,7 +18,13 @@ if ExtVerifier.has_rails?
     t.datetime :created_at
   end
 
+  ActiveRecord::Migration.create_table :emails do |t|
+    t.references :user
+    t.string :email_address
+  end
+
   # Create models
-  class User < ActiveRecord::Base; end
+  class User < ActiveRecord::Base; has_many :emails; end
   class SubUser < User; end
+  class Email < ActiveRecord::Base; belongs_to :user; end
 end

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -98,6 +98,27 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
     end
   end
 
+  describe 'Linked records (joins)' do
+    before do
+      @ap = AwesomePrint::Inspector.new(:plain => true)
+    end
+
+    it 'should show the entire record' do
+      e = Email.create(:email_address => 'foo@bar.com')
+      u = User.last
+      u.emails << e
+      email_record = User.joins(:emails).select('users.id, emails.email_address').last
+      out = @ap.awesome(email_record)
+      raw_object_string = <<-EOS.strip
+#<User:placeholder_id> {
+               "id" => #{u.id},
+    "email_address" => "#{e.email_address}"
+}
+EOS
+      expect(out).to be_similar_to(raw_object_string)
+    end
+  end
+
   #------------------------------------------------------------------------------
   describe "ActiveRecord instance (raw)" do
     before do


### PR DESCRIPTION
Display ActiveRecord#joins resulting objects as one would expect, i.e., with all the selected columns.
##### Example
###### Before
![Before](http://s15.postimg.org/5ilzg0n7f/before.png)
###### After
![After](http://s15.postimg.org/x4or0p6kb/after.png)