### PR TITLE
Handle NoMethodError for IRB implicit #ai

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.6.2 (unreleased)
   - Improves spec performance and simplicity (Mauro George)
   - Handle objects that have a custom #to_hash method (Elliot Shank)
+  - Handle NoMethodError for IRB implicit #ai (Julien Negrotto)
 
 1.6.1
   - Fixes specs on all rails dependencies (Mauro George)

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -29,6 +29,8 @@ module AwesomePrint
         IRB::Irb.class_eval do
           def output_value
             ap @context.last_value
+          rescue NoMethodError
+            puts "(Object doesn't support #ai)"
           end
         end
       else # MacRuby
@@ -53,7 +55,7 @@ module AwesomePrint
     AP = :__awesome_print__
 
     def initialize(options = {})
-      @options = { 
+      @options = {
         :indent     => 4,      # Indent using 4 spaces.
         :index      => true,   # Display array indices.
         :html       => false,  # Use ANSI color codes rather than HTML.
@@ -62,7 +64,7 @@ module AwesomePrint
         :raw        => false,  # Do not recursively format object instance variables.
         :sort_keys  => false,  # Do not sort hash keys.
         :limit      => false,  # Limit large output for arrays and hashes. Set to a boolean or integer.
-        :color => { 
+        :color => {
           :args       => :pale,
           :array      => :white,
           :bigdecimal => :blue,
@@ -92,7 +94,7 @@ module AwesomePrint
       @formatter = AwesomePrint::Formatter.new(self)
       Thread.current[AP] ||= []
     end
-  
+
     # Dispatcher that detects data nesting and invokes object-aware formatter.
     #------------------------------------------------------------------------------
     def awesome(object)

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -246,5 +246,17 @@ EOS
       expect(capture! { ap({ :a => 1 }) }).to eq(nil)
       Object.instance_eval{ remove_const :IRB }
     end
+
+    it "handles NoMethodError on IRB implicit #ai" do
+      module IRB; class Irb; end; end
+      irb_context = double('irb_context', last_value: BasicObject.new)
+      IRB.define_singleton_method :version, -> { 'test_version' }
+      irb = IRB::Irb.new
+      irb.instance_eval { @context = irb_context }
+      AwesomePrint.irb!
+      expect(irb).to receive(:puts).with("(Object doesn't support #ai)")
+      expect { irb.output_value }.to_not raise_error
+      Object.instance_eval { remove_const :IRB }
+    end
   end
 end


### PR DESCRIPTION
When the last value is inspected in `IRB::Irb::output_value`, it rescues NoMethodError in case the object doesn't support `#inspect` (e.g. a BasicObject), and prints a notification instead. I just added that back into `#output_value` (but for `#ai` instead of `#inspect`).

Plain IRB:

    irb(main):001:0> BasicObject.new
    (Object doesn't support #inspect)
    =>

Awesome Print:

    irb(main):001:0> BasicObject.new
    NoMethodError: undefined method `ai' for #<BasicObject:0x00564d08fd98b8>
      from /home/julien/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/awesome_print-1.6.2/lib/awesome_print/core_ext/kernel.rb:20:in `ap'
      from /home/julien/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/awesome_print-1.6.2/lib/awesome_print/inspector.rb:31:in `output_value'
      from /home/julien/.rbenv/versions/2.2.3/bin/irb:11:in `<main>'