### PR TITLE
Refactoring array formatter

### DIFF
--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -13,25 +13,15 @@ module AwesomePrint
       end
 
       def format
-        return "[]" if array == []
-
-        if array.instance_variable_defined?('@__awesome_methods__')
-          methods_array(array)
-        elsif options[:multiline]
-          width = (array.size - 1).to_s.size
-
-          data = array.inject([]) do |arr, item|
-            index = indent
-            index << colorize("[#{arr.size.to_s.rjust(width)}] ", :array) if options[:index]
-            indented do
-              arr << (index << inspector.awesome(item))
-            end
-          end
-
-          data = limited(data, width) if should_be_limited?
-          "[\n" << data.join(",\n") << "\n#{outdent}]"
+        case
+        when array.empty?
+          empty_array
+        when awesome_array?
+          methods_array
+        when multiline_array?
+          multiline_array
         else
-          "[ " << array.map{ |item| inspector.awesome(item) }.join(", ") << " ]"
+          simple_array
         end
       end
 

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -52,8 +52,8 @@ module AwesomePrint
       end
 
       def generate_printable_array
-        array.map.with_index do |item, i|
-          array_prefix(i, width(array)).tap do |temp|
+        array.map.with_index do |item, index|
+          array_prefix(index, width(array)).tap do |temp|
             indented { temp << inspector.awesome(item) } 
           end
         end
@@ -76,8 +76,8 @@ module AwesomePrint
       end
 
       def generate_printable_tuples
-        tuples.map.with_index do |item, i|
-          tuple_prefix(i, width(tuples)).tap do |temp|
+        tuples.map.with_index do |item, index|
+          tuple_prefix(index, width(tuples)).tap do |temp|
             indented { temp << tuple_template(item) }
           end
         end


### PR DESCRIPTION
Trying to move this beast from D to A. Any help, consideration or critic is welcome.

@gerrywastaken @michaeldv What do you think? I'm going to hold this until I can safely benchmark.
# TODO:
- [x] Complex method #multiline_array.
- [x] Complex method #tuples.
- [ ] Limit array while processing.
# Considerations:
- [#array _prefix](https://github.com/awesome-print/awesome_print/pull/246/files#diff-d38e1087bf89bafb7e477570e614719bR62) and [#tuple_prefix](https://github.com/awesome-print/awesome_print/pull/246/files#diff-d38e1087bf89bafb7e477570e614719bR110) is almost the same method except for one space.
- [limiting an array](https://github.com/awesome-print/awesome_print/pull/246/files#diff-d38e1087bf89bafb7e477570e614719bR48) could be way better if we limit while processing.
- [#generate_printable_array](https://github.com/awesome-print/awesome_print/pull/246/files#diff-d38e1087bf89bafb7e477570e614719bR54) and [#generate_printable_tuples](https://github.com/awesome-print/awesome_print/pull/246/files#diff-d38e1087bf89bafb7e477570e614719bR78) is almost the same thing except for the prefix. The rest can be yielded.
