### PR TITLE
Update urls to point to awesome-print organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We love pull requests. Here's a quick guide:
 
 1. Create your feature branch (`git checkout -b my-new-feature`)
 
-1. Update [CHANGELOG.md](https://github.com/michaeldv/awesome_print/blob/master/CHANGELOG.md) with a brief description of your changes under the `unreleased` heading.
+1. Update [CHANGELOG.md](https://github.com/awesome-print/awesome_print/blob/master/CHANGELOG.md) with a brief description of your changes under the `unreleased` heading.
 
 1. Add/Update tests were appropriate
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Climate][code_climate_badge]][code_climate]
 [![Code Climate Coverage][code_climate_coverage_badge]][code_climate]
 [![RubyGems][gem_downloads_badge]][ruby_gems]
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/michaeldv/awesome_print?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/awesome-print/awesome_print?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 Awesome Print is a Ruby library that pretty prints Ruby objects in full color
@@ -21,7 +21,7 @@ v2.0 will *require* Ruby v1.9.3 or later and Rails v3.0 or later.
     $ gem install awesome_print
 
     # Cloning the repository
-    $ git clone git://github.com/michaeldv/awesome_print.git
+    $ git clone git://github.com/awesome-print/awesome_print.git
 
 ### Usage ###
 
@@ -340,8 +340,8 @@ Released under the MIT license. See LICENSE file for details.
 [gem_version_badge]: https://img.shields.io/gem/v/awesome_print.svg?style=flat
 [gem_downloads_badge]: http://img.shields.io/gem/dt/awesome_print.svg?style=flat
 [ruby_gems]: http://rubygems.org/gems/awesome_print
-[travis_ci]: http://travis-ci.org/michaeldv/awesome_print
-[travis_ci_badge]: https://img.shields.io/travis/michaeldv/awesome_print/master.svg?style=flat
-[code_climate]: https://codeclimate.com/github/michaeldv/awesome_print
-[code_climate_badge]: http://img.shields.io/codeclimate/github/michaeldv/awesome_print.svg?style=flat
-[code_climate_coverage_badge]: https://codeclimate.com/github/michaeldv/awesome_print/badges/coverage.svg
+[travis_ci]: http://travis-ci.org/awesome-print/awesome_print
+[travis_ci_badge]: https://img.shields.io/travis/awesome-print/awesome_print/master.svg?style=flat
+[code_climate]: https://codeclimate.com/github/awesome-print/awesome_print
+[code_climate_badge]: http://img.shields.io/codeclimate/github/awesome-print/awesome_print.svg?style=flat
+[code_climate_coverage_badge]: https://codeclimate.com/github/awesome-print/awesome_print/badges/coverage.svg

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe "Methods arrays" do
     expect(out).to eq("[\n    [0] none() Hello\n    [1]  one() Hello\n]")
   end
 
-  # See https://github.com/michaeldv/awesome_print/issues/30 for details.
+  # See https://github.com/awesome-print/awesome_print/issues/30 for details.
   it "grepping methods and converting them to_sym should work as expected" do
     class Hello
       private

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe "AwesomePrint" do
       expect(weird.new.ai(:plain => false)).to eq("ice")
     end
 
-    # See https://github.com/michaeldv/awesome_print/issues/35
+    # See https://github.com/awesome-print/awesome_print/issues/35
     it "handle array grep when pattern contains / chapacter" do
       hash = { "1/x" => 1,  "2//x" => :"2" }
       grepped = hash.keys.sort.grep(/^(\d+)\//) { $1 }
       expect(grepped.ai(:plain => true, :multiline => false)).to eq('[ "1", "2" ]')
     end
 
-    # See https://github.com/michaeldv/awesome_print/issues/85
+    # See https://github.com/awesome-print/awesome_print/issues/85
     if RUBY_VERSION >= "1.8.7"
       it "handle array grep when a method is defined in C and thus doesn't have a binding" do
         arr = (0..6).to_a
@@ -58,14 +58,14 @@ RSpec.describe "AwesomePrint" do
       expect(ENV.ai).to eq(ENV.to_hash.ai)
     end
 
-    # See https://github.com/michaeldv/awesome_print/issues/134
+    # See https://github.com/awesome-print/awesome_print/issues/134
     it "IPAddr workaround" do
       require "ipaddr"
       ipaddr = IPAddr.new("3ffe:505:2::1")
       expect(ipaddr.ai).to eq("#<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>")
     end
 
-    # See https://github.com/michaeldv/awesome_print/issues/139
+    # See https://github.com/awesome-print/awesome_print/issues/139
     it "Object that overrides == and expects the :id method" do
       weird = Class.new do
         # Raises NoMethodError: undefined method `id' when "other" is nil or ENV.
@@ -137,7 +137,7 @@ EOS
       AwesomePrint.defaults = nil
     end
 
-    # See https://github.com/michaeldv/awesome_print/issues/98
+    # See https://github.com/awesome-print/awesome_print/issues/98
     it "should properly merge the defaults" do
       AwesomePrint.defaults = { :indent => -2, :sort_keys => true }
       hash = { [0, 0, 255] => :yellow, :red => "rgb(255, 0, 0)", "magenta" => "rgb(255, 0, 255)" }


### PR DESCRIPTION
Quite a few places, still pointed to the old repository making them invalid. This commit just updates those urls to point to the urls underneath the awesome-print organization github account.

One of the things that this fixes is the Travis status which currently is showing up as "invalid".

Commit message:
---
Before this commit a number or our urls were out of date which
lead to problems such as our build status on Travis being invalid
and people being asked to clone from an old version of the
repository.

Thanks to Michael Dvorkin for his many years of incredible work
on this project and for creating this organization so that the
project could live on with the help of others.