### PR TITLE
Add/struct formatter

### DIFF
--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -80,7 +80,7 @@ module AwesomePrint
     end
 
     def awesome_object(o)
-      Formatters::ObjectFormatter.new(o, o.instance_variables, @inspector).format
+      Formatters::ObjectFormatter.new(o, @inspector).format
     end
 
     def awesome_struct(s)

--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -84,7 +84,7 @@ module AwesomePrint
     end
 
     def awesome_struct(s)
-      Formatters::ObjectFormatter.new(s, s.members, @inspector).format
+      Formatters::StructFormatter.new(s, @inspector).format
     end
 
     def awesome_method(m)

--- a/lib/awesome_print/formatters.rb
+++ b/lib/awesome_print/formatters.rb
@@ -1,6 +1,7 @@
 module AwesomePrint
   module Formatters
     require 'awesome_print/formatters/object_formatter'
+    require 'awesome_print/formatters/struct_formatter'
     require 'awesome_print/formatters/hash_formatter'
     require 'awesome_print/formatters/array_formatter'
     require 'awesome_print/formatters/simple_formatter'

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -6,9 +6,9 @@ module AwesomePrint
 
       attr_reader :object, :variables, :inspector, :options
 
-      def initialize(object, variables, inspector)
+      def initialize(object, inspector)
         @object = object
-        @variables = variables
+        @variables = object.instance_variables
         @inspector = inspector
         @options = inspector.options
       end
@@ -42,13 +42,7 @@ module AwesomePrint
           end
 
           indented do
-            var_contents = if valid_instance_var?(var)
-              object.instance_variable_get(var)
-            else
-              object.send(var) # Enables handling of Struct attributes
-            end
-
-            key << colorize(" = ", :hash) + inspector.awesome(var_contents)
+            key << colorize(" = ", :hash) + inspector.awesome(object.instance_variable_get(var))
           end
         end
 

--- a/lib/awesome_print/formatters/struct_formatter.rb
+++ b/lib/awesome_print/formatters/struct_formatter.rb
@@ -1,0 +1,70 @@
+require_relative 'base_formatter'
+
+module AwesomePrint
+  module Formatters
+    class StructFormatter < BaseFormatter
+
+      attr_reader :struct, :variables, :inspector, :options
+
+      def initialize(struct, inspector)
+        @struct = struct
+        @variables = struct.members
+        @inspector = inspector
+        @options = inspector.options
+      end
+
+      def format
+        vars = variables.map do |var|
+          property = var.to_s[1..-1].to_sym # to_s because of some monkey patching done by Puppet.
+          accessor = if struct.respond_to?(:"#{property}=")
+            struct.respond_to?(property) ? :accessor : :writer
+          else
+            struct.respond_to?(property) ? :reader : nil
+          end
+          if accessor
+            [ "attr_#{accessor} :#{property}", var ]
+          else
+            [ var.to_s, var ]
+          end
+        end
+
+        data = vars.sort.map do |declaration, var|
+          key = left_aligned do
+            align(declaration, declaration.size)
+          end
+
+          unless options[:plain]
+            if key =~ /(@\w+)/
+              key.sub!($1, colorize($1, :variable))
+            else
+              key.sub!(/(attr_\w+)\s(\:\w+)/, "#{colorize('\\1', :keyword)} #{colorize('\\2', :method)}")
+            end
+          end
+
+          indented do
+            key << colorize(" = ", :hash) + inspector.awesome(struct.send(var))
+          end
+        end
+
+        if options[:multiline]
+          "#<#{awesome_instance}\n#{data.join(%Q/,\n/)}\n#{outdent}>"
+        else
+          "#<#{awesome_instance} #{data.join(', ')}>"
+        end
+      end
+
+      private
+
+      def awesome_instance
+        "#{struct.class.superclass}:#{struct.class}:0x%08x" % (struct.__id__ * 2)
+      end
+
+      def left_aligned
+        current, options[:indent] = options[:indent], 0
+        yield
+      ensure
+        options[:indent] = current
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR solves #168.

It:
- Changes ObjectFormatter to a previous state. Taken ObjectFormatter from 68431d0475f7355d5a3ce268c78812ac6576041d
- Creates a formatter for structs which is almost the same thing of the object formatter.
  - The formatter prints out the superclass of the Struct.
  - There will be a refactoring on both in a near future to achieve Code Climate 4.0.