### PR TITLE
Allow non `.aprc` `File.readable?` calls

### DIFF
--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -173,7 +173,7 @@ module AwesomePrint
     # Load ~/.aprc file with custom defaults that override default options.
     #------------------------------------------------------------------------------
     def merge_custom_defaults!
-      dotfile = File.join(ENV["HOME"], ".aprc")
+      dotfile = File.join(ENV['HOME'], '.aprc')
       load dotfile if File.readable?(dotfile)
       merge_options!(AwesomePrint.defaults) if AwesomePrint.defaults.is_a?(Hash)
     rescue => e

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,8 @@ def normalize_object_id_strings(str, options)
 end
 
 def stub_dotfile!
-  dotfile = File.join(ENV["HOME"], ".aprc")
+  dotfile = File.join(ENV['HOME'], '.aprc')
+  allow(File).to receive(:readable?).and_call_original
   expect(File).to receive(:readable?).at_least(:once).with(dotfile).and_return(false)
 end
 


### PR DESCRIPTION
`stub_dotfile!` was blocking all calls to `File.readable?` instead
of just calls to load the `.aprc` file. This meant that trying to
use other libraries, such as pry, which relied on `File.readable?`
would fail in instances where `stub_dotfile!` had been called.

This change fixes that, while keeping the original intended
behaviour.