### PR TITLE
Lock activesupport for our 1.9.3 build

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -49,4 +49,8 @@ end
 
 appraise 'nobrainer' do
   gem 'nobrainer'
+
+  # When activesupport 5 was released, it required ruby 2.2.2 as a minimum.
+  # Locking this down to 4.2.6 allows our Ruby 1.9 tests to keep working.
+  gem 'activesupport', '4.2.6', :platforms => :ruby_19
 end

--- a/gemfiles/nobrainer.gemfile
+++ b/gemfiles/nobrainer.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "nobrainer"
+gem "activesupport", "4.2.6", :platforms => :ruby_19
 
 gemspec :path => "../"


### PR DESCRIPTION
`activesupport` 5.0 requires Ruby 2.2.2, so locking down the version is necessary for the `nobrainer` tests. I believe our other tests are not running into the same issue as they already lock us to things such as earlier versions of rails which have requirements on earlier versions of activesupport.

If it turns out that other appraisal gemsets also need activesupport to be locked down then I'll add them as we encounter build issues.