### PR TITLE
Add `rubycop` and `reek` checking to codeclimate

### DIFF
--- a/.codeclimate
+++ b/.codeclimate
@@ -1,0 +1,3 @@
+engines:
+  rubocop:
+    enabled: true

--- a/.codeclimate
+++ b/.codeclimate
@@ -1,3 +1,5 @@
 engines:
   rubocop:
     enabled: true
+  reek:
+    enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,16 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  DisabledByDefault: false


### PR DESCRIPTION
@waldyr What do you think about adding the Rubocop engine to our code climate config?

https://docs.codeclimate.com/docs/rubocop

Commit Message:
-----------

According to the Contributing guide
(https://github.com/awesome-print/awesome_print/blob/master/CONTRIBUTING.md)
we encourage sticking to the Ruby style guide. However our code
climate setup does not use the Rubocop engine to check against
this style guide.

This commit enables the Rubocop checking. I'm not 100% sure if this
affects the code climate score, but even if it is I think this is
for the best as currently we are just hiding the issues.