### PR TITLE
Fix build issue with `json` gem

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,6 +4,7 @@ end
 
 appraise 'rails-4.0' do
   gem 'rails', '~> 4.0.0'
+  gem 'json',  '~> 1.8', :platforms => :ruby_19 # Json 2.0 requires Ruby >= 2.0
 
   # The last version that doesn't need Ruby 2.0 and works with version 4.0 of
   # Rails. This addresses a build problem with Travis for version 1.9.3 of Ruby
@@ -37,6 +38,7 @@ end
 
 appraise 'mongoid-3.1' do
   gem 'mongoid', '~> 3.1.0'
+  gem 'json',  '~> 1.8', :platforms => :ruby_19 # Json 2.0 requires Ruby >= 2.0
 end
 
 appraise 'mongoid-4.0' do

--- a/gemfiles/mongoid_3.1.gemfile
+++ b/gemfiles/mongoid_3.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "mongoid", "~> 3.1.0"
+gem "json", "~> 1.8", :platforms => :ruby_19
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
+gem "json", "~> 1.8", :platforms => :ruby_19
 gem "mime-types", "2.6.2", :platforms => :ruby_19
 
 gemspec :path => "../"


### PR DESCRIPTION
The new `json` gem requires Ruby >= 2.0
This locks down the version of json to address a recent break in
our builds caused by this issue.