### PR TITLE
Make option name more meaningful

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ ap object, options = {}
 Default options:
 
 ```ruby
-indent:          4,      # Number of spaces for indenting.
-index:           true,   # Display array indices.
-html:            false,  # Use ANSI color codes rather than HTML.
-multiline:       true,   # Display in multiple lines.
-plain:           false,  # Use colors.
-raw:             false,  # Do not recursively format instance variables.
-sort_keys:       false,  # Do not sort hash keys.
-limit:           false,  # Limit arrays & hashes. Accepts bool or int.
-new_hash_syntax: false,  # Use Ruby 1.9 hash syntax in output.
+indent:        4,      # Number of spaces for indenting.
+index:         true,   # Display array indices.
+html:          false,  # Use ANSI color codes rather than HTML.
+multiline:     true,   # Display in multiple lines.
+plain:         false,  # Use colors.
+raw:           false,  # Do not recursively format instance variables.
+sort_keys:     false,  # Do not sort hash keys.
+limit:         false,  # Limit arrays & hashes. Accepts bool or int.
+ruby19_syntax: false,  # Use Ruby 1.9 hash syntax in output.
 color: {
   args:       :pale,
   array:      :white,

--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -28,10 +28,10 @@ module AwesomePrint
 
         data = data.map do |key, value|
           indented do
-            if options[:new_hash_syntax] && symbol?(key)
-              new_hash_syntax(key, value, width)
+            if options[:ruby19_syntax] && symbol?(key)
+              ruby19_syntax(key, value, width)
             else
-              old_hash_syntax(key, value, width)
+              pre_ruby19_syntax(key, value, width)
             end
           end
         end
@@ -50,12 +50,12 @@ module AwesomePrint
         k.first == ':'
       end
 
-      def new_hash_syntax(k, v, width)
+      def ruby19_syntax(k, v, width)
         k[0] = ''
         align(k, width - 1) << colorize(": ", :hash) << inspector.awesome(v)
       end
 
-      def old_hash_syntax(k, v, width)
+      def pre_ruby19_syntax(k, v, width)
         align(k, width) << colorize(" => ", :hash) << inspector.awesome(v)
       end
 

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -13,15 +13,15 @@ module AwesomePrint
 
     def initialize(options = {})
       @options = {
-        indent:          4,      # Number of spaces for indenting.
-        index:           true,   # Display array indices.
-        html:            false,  # Use ANSI color codes rather than HTML.
-        multiline:       true,   # Display in multiple lines.
-        plain:           false,  # Use colors.
-        raw:             false,  # Do not recursively format instance variables.
-        sort_keys:       false,  # Do not sort hash keys.
-        limit:           false,  # Limit arrays & hashes. Accepts bool or int.
-        new_hash_syntax: false,  # Use Ruby 1.9 hash syntax in output.
+        indent:        4,      # Number of spaces for indenting.
+        index:         true,   # Display array indices.
+        html:          false,  # Use ANSI color codes rather than HTML.
+        multiline:     true,   # Display in multiple lines.
+        plain:         false,  # Use colors.
+        raw:           false,  # Do not recursively format instance variables.
+        sort_keys:     false,  # Do not sort hash keys.
+        limit:         false,  # Limit arrays & hashes. Accepts bool or int.
+        ruby19_syntax: false,  # Use Ruby 1.9 hash syntax in output.
         color: {
           args:       :pale,
           array:      :white,

--- a/spec/formats_spec.rb
+++ b/spec/formats_spec.rb
@@ -276,7 +276,7 @@ EOS
     end
 
     it "new hash syntax" do
-      expect(@hash.ai(:plain => true, :new_hash_syntax => true)).to eq <<-EOS.strip
+      expect(@hash.ai(:plain => true, :ruby19_syntax => true)).to eq <<-EOS.strip
 {
     1 => {
         sym: {
@@ -328,7 +328,7 @@ EOS
     end
 
     it "colored with new hash syntax" do
-      expect(@hash.ai(:new_hash_syntax => true)).to eq <<-EOS.strip
+      expect(@hash.ai(:ruby19_syntax => true)).to eq <<-EOS.strip
 {
     1\e[0;37m => \e[0m{
         sym\e[0;37m: \e[0m{


### PR DESCRIPTION
@waldyr: @alexch and @imajes raised some good points about the naming of the `new_hash_syntax` option (https://github.com/awesome-print/awesome_print/pull/193/commits/188becfadfbff3b5fd952e0366bf36c8c6f59b59#r26746035). I only just spotted these comments and I think they raise good points. So I propose `ruby19_syntax` as the symbol name. Glad I spotted this before we released.

Commit message:
----------

I just noticed a code review which suggested against the name
we are currently using and gave some good reasoning:

"Naming things "new" is always a problem (since time passes and
it's no longer new). Maybe colonize_symbol_keys? ("colonize"
sounds kind of gross though...)
https://git.io/vKIiX

The ruby19_syntax name was suggested later in the conversation.

As we have not yet released with the previous option name, it's
now or never for this change.