### PR TITLE
Performance tunings for awesome methods

### DIFF
--- a/lib/awesome_print/core_ext/array.rb
+++ b/lib/awesome_print/core_ext/array.rb
@@ -13,18 +13,25 @@
 # If you could think of a better way please let me know :-)
 #
 class Array #:nodoc:
-  [ :-, :& ].each do |operator|
-    original_operator = instance_method(operator)
 
-    define_method operator do |*args|
-      arr = original_operator.bind(self).call(*args)
-      if self.instance_variable_defined?(:@__awesome_methods__)
-        arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
-        arr.sort! { |a, b| a.to_s <=> b.to_s }  # Need the block since Ruby 1.8.x can't sort arrays of symbols.
-      end
-      arr
+  alias :difference_without_awesome_print :-
+  def -(other_ary)
+    arr = difference_without_awesome_print(other_ary)
+    if self.instance_variable_defined?(:@__awesome_methods__)
+      arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
     end
+    arr
   end
+
+  alias :intersection_without_awesome_print :&
+  def &(other_ary)
+    arr = intersection_without_awesome_print(other_ary)
+    if self.instance_variable_defined?(:@__awesome_methods__)
+      arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
+    end
+    arr
+  end
+
   #
   # Intercepting Array#grep needs a special treatment since grep accepts
   # an optional block.

--- a/lib/awesome_print/core_ext/array.rb
+++ b/lib/awesome_print/core_ext/array.rb
@@ -18,8 +18,8 @@ class Array #:nodoc:
 
     define_method operator do |*args|
       arr = original_operator.bind(self).call(*args)
-      if self.instance_variable_defined?('@__awesome_methods__')
-        arr.instance_variable_set('@__awesome_methods__', self.instance_variable_get('@__awesome_methods__'))
+      if self.instance_variable_defined?(:@__awesome_methods__)
+        arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
         arr.sort! { |a, b| a.to_s <=> b.to_s }  # Need the block since Ruby 1.8.x can't sort arrays of symbols.
       end
       arr
@@ -72,8 +72,8 @@ class Array #:nodoc:
         yield match
       end
     end
-    if self.instance_variable_defined?('@__awesome_methods__')
-      arr.instance_variable_set('@__awesome_methods__', self.instance_variable_get('@__awesome_methods__'))
+    if self.instance_variable_defined?(:@__awesome_methods__)
+      arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
       arr.reject! { |item| !(item.is_a?(Symbol) || item.is_a?(String)) } # grep block might return crap.
     end
     arr

--- a/lib/awesome_print/core_ext/class.rb
+++ b/lib/awesome_print/core_ext/class.rb
@@ -15,7 +15,7 @@ class Class #:nodoc:
 
     define_method name do |*args|
       methods = original_method.bind(self).call(*args)
-      methods.instance_variable_set('@__awesome_methods__', self)
+      methods.instance_variable_set(:@__awesome_methods__, self)
       methods
     end
   end

--- a/lib/awesome_print/core_ext/object.rb
+++ b/lib/awesome_print/core_ext/object.rb
@@ -15,7 +15,7 @@ class Object #:nodoc:
 
     define_method name do |*args|
       methods = original_method.bind(self).call(*args)
-      methods.instance_variable_set('@__awesome_methods__', self)
+      methods.instance_variable_set(:@__awesome_methods__, self)
       methods
     end
   end

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -15,7 +15,7 @@ module AwesomePrint
       def format
         return "[]" if array == []
 
-        if array.instance_variable_defined?('@__awesome_methods__')
+        if array.instance_variable_defined?(:@__awesome_methods__)
           methods_array(array)
         elsif options[:multiline]
           width = (array.size - 1).to_s.size
@@ -39,7 +39,7 @@ module AwesomePrint
 
       def methods_array(a)
         a.sort! { |x, y| x.to_s <=> y.to_s }                  # Can't simply a.sort! because of o.methods << [ :blah ]
-        object = a.instance_variable_get('@__awesome_methods__')
+        object = a.instance_variable_get(:@__awesome_methods__)
         tuples = a.map do |name|
           if name.is_a?(Symbol) || name.is_a?(String)         # Ignore garbage, ex. 42.methods << [ :blah ]
             tuple = if object.respond_to?(name, true)         # Is this a regular method?


### PR DESCRIPTION
The extensions to Array and a few other classes introduce a performance issue when awesome_print is loaded. This performance slowdown happens even when objects are not being printed. The main place this would be noticed in when taking the difference between two arrays.

This PR reduces the overhead of `Array#-` from **2.5x slower** to only **1.1x slower** and completely eliminates extraneous object creation.

The two main causes of the performance issue are
* The use of `define_method` to override methods. This requires the original method to be bound (allocating a Method object) and then called (allocating an Array of the args) on every method invocation.
* The use of unfrozen Strings where a Symbol can be used.
 
This [benchmark script] (https://gist.github.com/dgynn/0ee1ae8af279aa417f8aec5328ee6326) can be used to compare the performance before and after loading awesome_print and its extensions to Array and others. It tests the performance of...
```ruby
[1,2,3,4,5] - [3,4,5,6,7]
```

Here are the results of the benchmark script runs. "Before" means before requiring awesome_print and IPS means iterations per second. At least 1 object must be created in all cases which is the result Array.
```
# Initial results
Before IPS: 1363785.204974598
After IPS: 540003.9100471758
Speed difference: 2.5255098705775203
Before allocated: 40 bytes (1 objects)
After  allocated: 248 bytes (5 objects)
Memory difference: +208 bytes
Memory difference: +4 objects

# Results after converting Strings to Symbols for instance variables
Before IPS: 1331499.3192977062
After IPS: 565391.1058412988
Speed difference: 2.355005774836947
Before allocated: 40 bytes (1 objects)
After  allocated: 208 bytes (4 objects)
Memory difference: +168 bytes
Memory difference: +3 objects

# Results after directly overriding methods
Before IPS: 1441087.4199060071
After IPS: 1298607.328987272
Speed difference: 1.1097176088093152
Before allocated: 40 bytes (1 objects)
After  allocated: 40 bytes (1 objects)
Memory difference: +0 bytes
Memory difference: +0 objects
```
