### PR TITLE
Fix/bad defaults in random spec order

### DIFF
--- a/lib/awesome_print/ext/action_view.rb
+++ b/lib/awesome_print/ext/action_view.rb
@@ -5,13 +5,17 @@
 #------------------------------------------------------------------------------
 module AwesomePrint
   module ActionView
-
     # Use HTML colors and add default "debug_dump" class to the resulting HTML.
     def ap_debug(object, options = {})
-      object.ai(options.merge(:html => true)).sub(/^<pre([\s>])/, '<pre class="debug_dump"\\1')
+      object.ai(
+        options.merge(html: true)
+      ).sub(
+        /^<pre([\s>])/,
+        '<pre class="debug_dump"\\1'
+      )
     end
 
-    alias_method :ap, :ap_debug
+    alias ap ap_debug
   end
 end
 

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -137,11 +137,18 @@ module AwesomePrint
       @options.merge!(options)
     end
 
+    # This method needs to be mocked during testing so that it always loads
+    # predictable values
+    #---------------------------------------------------------------------------
+    def load_dotfile
+      dotfile = File.join(ENV['HOME'], '.aprc')
+      load dotfile if File.readable?(dotfile)
+    end
+
     # Load ~/.aprc file with custom defaults that override default options.
     #---------------------------------------------------------------------------
     def merge_custom_defaults!
-      dotfile = File.join(ENV['HOME'], '.aprc')
-      load dotfile if File.readable?(dotfile)
+      load_dotfile
       merge_options!(AwesomePrint.defaults) if AwesomePrint.defaults.is_a?(Hash)
     rescue => e
       $stderr.puts "Could not load #{dotfile}: #{e}"

--- a/spec/colors_spec.rb
+++ b/spec/colors_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe "AwesomePrint" do
     end
   end
 
-  before do
-    stub_dotfile!
-  end
-
   describe "colorization" do
     PLAIN = '[ 1, :two, "three", [ nil, [ true, false ] ] ]'
     COLORIZED = "[ \e[1;34m1\e[0m, \e[0;36m:two\e[0m, \e[0;33m\"three\"\e[0m, [ \e[1;31mnil\e[0m, [ \e[1;32mtrue\e[0m, \e[1;31mfalse\e[0m ] ] ]"
@@ -67,7 +63,7 @@ RSpec.describe "AwesomePrint" do
       before do
         AwesomePrint.force_colors!
       end
-      
+
       it "still colorizes tty processes" do
         stub_tty!
         expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
@@ -82,7 +78,7 @@ RSpec.describe "AwesomePrint" do
           ENV['ANSICON'] = term
         end
       end
-      
+
       it "colorizes dumb terminals" do
         begin
           stub_tty!

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 require 'active_record_helper'
 
 RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.call do
-
-  before do
-    stub_dotfile!
-  end
-
-  #------------------------------------------------------------------------------
   describe "ActiveRecord instance, attributes only (default)" do
     before do
       ActiveRecord::Base.default_timezone = :utc

--- a/spec/ext/active_support_spec.rb
+++ b/spec/ext/active_support_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 RSpec.describe "AwesomePrint::ActiveSupport", skip: ->{ !ExtVerifier.has_rails? }.call do
   before do
-    stub_dotfile!
     @ap = AwesomePrint::Inspector.new
   end
 

--- a/spec/ext/mongo_mapper_spec.rb
+++ b/spec/ext/mongo_mapper_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapper? }.call do
-
   if ExtVerifier.has_mongo_mapper?
     before :all do
       class MongoUser
@@ -19,7 +18,6 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
   end
 
   before do
-    stub_dotfile!
     @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true)
   end
 

--- a/spec/ext/mongoid_spec.rb
+++ b/spec/ext/mongoid_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "AwesomePrint/Mongoid", skip: ->{ !ExtVerifier.has_mongoid? }.cal
   end
 
   before do
-    stub_dotfile!
     @ap = AwesomePrint::Inspector.new :plain => true, :sort_keys => true
   end
 

--- a/spec/ext/nobrainer_spec.rb
+++ b/spec/ext/nobrainer_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "AwesomePrint/NoBrainer", skip: ->{ !ExtVerifier.has_nobrainer? }
   end
 
   before do
-    stub_dotfile!
     @ap = AwesomePrint::Inspector.new :plain => true
   end
 

--- a/spec/ext/nokogiri_spec.rb
+++ b/spec/ext/nokogiri_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe "AwesomePrint/Nokogiri" do
-  before do
-    stub_dotfile!
-  end
-
   it "should colorize tags" do
     xml = Nokogiri::XML('<html><body><h1></h1></body></html>')
     expect(xml.ai).to eq  <<-EOS

--- a/spec/ext/ostruct_spec.rb
+++ b/spec/ext/ostruct_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 RSpec.describe 'AwesomePrint Ostruct extension' do
   before do
-    stub_dotfile!
     @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true)
   end
 

--- a/spec/ext/ripple_spec.rb
+++ b/spec/ext/ripple_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'AwesomePrint/Ripple', skip: ->{ !ExtVerifier.has_ripple? }.call 
   end
 
   before do
-    stub_dotfile!
     @ap = AwesomePrint::Inspector.new :plain => true, :sort_keys => true
   end
 

--- a/spec/formats_spec.rb
+++ b/spec/formats_spec.rb
@@ -4,10 +4,6 @@ require "rational"
 require "set"
 
 RSpec.describe "AwesomePrint" do
-  before do
-    stub_dotfile!
-  end
-
   describe "Array" do
     before do
       @arr = [ 1, :two, "three", [ nil, [ true, false] ] ]

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe "Single method" do
-  before do
-    stub_dotfile!
-  end
-
   after do
     Object.instance_eval{ remove_const :Hello } if defined?(Hello)
   end
@@ -81,10 +77,6 @@ RSpec.describe "Single method" do
 end
 
 RSpec.describe "Object methods" do
-  before do
-    stub_dotfile!
-  end
-
   after do
     Object.instance_eval{ remove_const :Hello } if defined?(Hello)
   end
@@ -203,10 +195,6 @@ RSpec.describe "Object methods" do
 end
 
 RSpec.describe "Class methods" do
-  before do
-    stub_dotfile!
-  end
-
   after do
     Object.instance_eval{ remove_const :Hello } if defined?(Hello)
   end

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 RSpec.describe "AwesomePrint" do
 
   describe "Misc" do
-    before do
-      stub_dotfile!
-    end
-
     it "handle weird objects that return nil on inspect" do
       weird = Class.new do
         def inspect
@@ -80,10 +76,6 @@ RSpec.describe "AwesomePrint" do
 
   #------------------------------------------------------------------------------
   describe "HTML output" do
-    before do
-      stub_dotfile!
-    end
-
     it "wraps ap output with plain <pre> tag" do
       markup = rand
       expect(markup.ai(:html => true, :plain => true)).to eq("<pre>#{markup}</pre>")
@@ -129,10 +121,6 @@ RSpec.describe "AwesomePrint" do
 
   #------------------------------------------------------------------------------
   describe "AwesomePrint.defaults" do
-    before do
-      stub_dotfile!
-    end
-
     after do
       AwesomePrint.defaults = nil
     end
@@ -154,10 +142,6 @@ RSpec.describe "AwesomePrint" do
 
   #------------------------------------------------------------------------------
   describe "Coexistence with the colorize gem" do
-    before do
-      stub_dotfile!
-    end
-
     before do # Redefine String#red just like colorize gem does it.
       @awesome_method = "".method(:red)
 

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe "Objects" do
-  before do
-    stub_dotfile!
-  end
-
   after do
     Object.instance_eval{ remove_const :Hello } if defined?(Hello)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,11 @@ RSpec.configure do |config|
   end
 
   config.default_formatter = 'doc' if config.files_to_run.one?
+
+  # Run before all examples. Using suite or all will not work as stubs are
+  # killed after each example ends.
+  config.before(:each) do |_example|
+    stub_dotfile!
   end
 end
 
@@ -80,9 +85,9 @@ def normalize_object_id_strings(str, options)
 end
 
 def stub_dotfile!
-  dotfile = File.join(ENV['HOME'], '.aprc')
-  allow(File).to receive(:readable?).and_call_original
-  expect(File).to receive(:readable?).at_least(:once).with(dotfile).and_return(false)
+  allow_any_instance_of(AwesomePrint::Inspector)
+    .to receive(:load_dotfile)
+    .and_return(true)
 end
 
 def capture!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,17 @@ Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each do |file|
   require file
 end
 
-ExtVerifier.require_dependencies!(%w{rails active_record action_view
-                                  active_support/all mongoid mongo_mapper ripple nobrainer})
+ExtVerifier.require_dependencies!(
+  %w(
+    rails
+    active_record
+    action_view
+    active_support/all
+    mongoid
+    mongo_mapper
+    ripple nobrainer
+  )
+)
 require 'nokogiri'
 require 'awesome_print'
 
@@ -42,8 +51,8 @@ RSpec.configure do |config|
     mocks.syntax = :expect
     mocks.verify_partial_doubles = true
   end
-  if config.files_to_run.one?
-    config.default_formatter = 'doc'
+
+  config.default_formatter = 'doc' if config.files_to_run.one?
   end
 end
 
@@ -77,7 +86,8 @@ def stub_dotfile!
 end
 
 def capture!
-  standard, $stdout = $stdout, StringIO.new
+  standard = $stdout
+  $stdout = StringIO.new
   yield
 ensure
   $stdout = standard


### PR DESCRIPTION
Improve stubbing of the dotfile so that we can run specs out of order and not have to worry that an earlier spec would have accidentally populated AwesomePrint.defaults because somebody forgot to call stub_dotfile!.

This now also means we can remove stub_dotfile! calls that were previously scattered through our specs.

I've also made the dotfile loading easier to stub and more reliable by pulling it out into it's own method which we can completely stub out instead of relying on the internal behaviour of the dotfile loading (ie. before we were stubbing a call to File.readable? which isn't really what stub_dotfile! should do).