### PR TITLE
Replace Rails method with Ruby equivilent

### DIFF
--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -47,7 +47,7 @@ module AwesomePrint
       private
 
       def symbol?(k)
-        k.first == ':'
+        k[0] == ':'
       end
 
       def ruby19_syntax(k, v, width)


### PR DESCRIPTION
There was a crash when accessing hashes while not inside a rails
environment. This was due to us accidentally using a String method
which is only available in Rails.