### PR TITLE
Additional performance tuning for Arrays

### DIFF
--- a/lib/awesome_print.rb
+++ b/lib/awesome_print.rb
@@ -8,7 +8,7 @@
 # so do nothing for subsequent requires.
 #
 unless defined?(AwesomePrint::Inspector)
-  %w(array string method object class kernel).each do |file|
+  %w(awesome_method_array string method object class kernel).each do |file|
     require "awesome_print/core_ext/#{file}"
   end
 

--- a/lib/awesome_print/core_ext/awesome_method_array.rb
+++ b/lib/awesome_print/core_ext/awesome_method_array.rb
@@ -12,31 +12,24 @@
 #
 # If you could think of a better way please let me know :-)
 #
-class Array #:nodoc:
+module AwesomeMethodArray #:nodoc:
 
-  alias :difference_without_awesome_print :-
-  def -(other_ary)
-    arr = difference_without_awesome_print(other_ary)
-    if self.instance_variable_defined?(:@__awesome_methods__)
+  def -(_other_ary)
+    super.tap do |arr|
       arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
     end
-    arr
   end
 
-  alias :intersection_without_awesome_print :&
-  def &(other_ary)
-    arr = intersection_without_awesome_print(other_ary)
-    if self.instance_variable_defined?(:@__awesome_methods__)
+  def &(_other_ary)
+    super.tap do |arr|
       arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
     end
-    arr
   end
 
   #
   # Intercepting Array#grep needs a special treatment since grep accepts
   # an optional block.
   #
-  alias :original_grep :grep
   def grep(pattern, &blk)
     #
     # The following looks rather insane and I've sent numerous hours trying
@@ -62,9 +55,9 @@ class Array #:nodoc:
     # the comment :-)
     #
     arr = unless blk
-      original_grep(pattern)
+      super(pattern)
     else
-      original_grep(pattern) do |match|
+      super(pattern) do |match|
         #
         # The binding can only be used with Ruby-defined methods, therefore
         # we must rescue potential "ArgumentError: Can't create Binding from
@@ -79,10 +72,8 @@ class Array #:nodoc:
         yield match
       end
     end
-    if self.instance_variable_defined?(:@__awesome_methods__)
-      arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
-      arr.reject! { |item| !(item.is_a?(Symbol) || item.is_a?(String)) } # grep block might return crap.
-    end
+    arr.instance_variable_set(:@__awesome_methods__, self.instance_variable_get(:@__awesome_methods__))
+    arr.reject! { |item| !(item.is_a?(Symbol) || item.is_a?(String)) } # grep block might return crap.
     arr
   end
 end

--- a/lib/awesome_print/core_ext/class.rb
+++ b/lib/awesome_print/core_ext/class.rb
@@ -16,6 +16,7 @@ class Class #:nodoc:
     define_method name do |*args|
       methods = original_method.bind(self).call(*args)
       methods.instance_variable_set(:@__awesome_methods__, self)
+      methods.extend(AwesomeMethodArray)
       methods
     end
   end

--- a/lib/awesome_print/core_ext/object.rb
+++ b/lib/awesome_print/core_ext/object.rb
@@ -16,6 +16,7 @@ class Object #:nodoc:
     define_method name do |*args|
       methods = original_method.bind(self).call(*args)
       methods.instance_variable_set(:@__awesome_methods__, self)
+      methods.extend(AwesomeMethodArray)
       methods
     end
   end


### PR DESCRIPTION
This is a follow-on from the changes in #264 and fully eliminates the performance overhead on Arrays when not working with arrays of methods.

Using the same [benchmark script](https://gist.github.com/dgynn/0ee1ae8af279aa417f8aec5328ee6326) as the previous PR will show the performance of any Array differencing is the same with or without awesome_print loaded. The timing for the benchmarks depends on the complexity of the arrays being tested. I'm seeing a **~35%** overhead eliminated for the simplest case of `[] - []`.

```
# Initial results (on master)
Before IPS: 6672995.80047777
After IPS: 4935828.68755387
Speed difference: 1.3519504470048407
Before allocated: 40 bytes (1 objects)
After  allocated: 40 bytes (1 objects)
Memory difference: +0 bytes
Memory difference: +0 objects

# Results after converting Array extensions to AwesomeMethodArray module
Before IPS: 6601333.422140501
After IPS: 6840107.4153905865
Speed difference: 0.9650920696489602
Before allocated: 40 bytes (1 objects)
After  allocated: 40 bytes (1 objects)
Memory difference: +0 bytes
Memory difference: +0 objects
```

@michaeldv You have a old, old comment in code for "If you could think of a better way please let me know" so I thought you might want to check this out too.
