### PR TITLE
Update to latest code climate method

### DIFF
--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fakefs", ">= 0.2.1"
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'nokogiri', '>= 1.6.5'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,9 @@
 # $ gem install bundler -v=1.0.2
 # $ gem install rspec -v=2.6.0
 #
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+
+require 'simplecov'
+SimpleCov.start
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 


### PR DESCRIPTION
According to the code climate docs we should no longer call their
runner at the top of our spec file and instead load simplecov.
Travis will then handle passing on the simplecov files to codecov.