### PR TITLE
Fix hash syntax inconsistency

### DIFF
--- a/lib/awesome_print/ext/mongo_mapper.rb
+++ b/lib/awesome_print/ext/mongo_mapper.rb
@@ -111,8 +111,8 @@ module AwesomePrint
     def apply_default_mongo_mapper_options
       @options[:color][:assoc] ||= :greenish
       @options[:mongo_mapper]  ||= {
-        :show_associations => false, # Display association data for MongoMapper documents and classes.
-        :inline_embedded => false    # Display embedded associations inline with MongoMapper documents.
+        show_associations: false, # Display association data for MongoMapper documents and classes.
+        inline_embedded: false    # Display embedded associations inline with MongoMapper documents.
       }
     end
   end

--- a/lib/awesome_print/ext/mongoid.rb
+++ b/lib/awesome_print/ext/mongoid.rb
@@ -48,9 +48,7 @@ module AwesomePrint
         hash[c[0].to_sym] = c[1]
         hash
       end
-      if !object.errors.empty?
-        data = {:errors => object.errors, :attributes => data}
-      end
+      data = {errors: object.errors, attributes: data} if !object.errors.empty?
       "#{object} #{awesome_hash(data)}"
     end
 

--- a/lib/awesome_print/ext/nobrainer.rb
+++ b/lib/awesome_print/ext/nobrainer.rb
@@ -38,9 +38,7 @@ module AwesomePrint
     #------------------------------------------------------------------------------
     def awesome_nobrainer_document(object)
       data = object.inspectable_attributes.symbolize_keys
-      if object.errors.present?
-        data = {:errors => object.errors, :attributes => data}
-      end
+      data = {errors: object.errors, attributes: data} if object.errors.present?
       "#{object} #{awesome_hash(data)}"
     end
   end

--- a/lib/awesome_print/ext/nokogiri.rb
+++ b/lib/awesome_print/ext/nokogiri.rb
@@ -27,7 +27,7 @@ module AwesomePrint
       if object.is_a?(::Nokogiri::XML::NodeSet) && object.empty?
         return '[]'
       end
-      xml = object.to_xml(:indent => 2)
+      xml = object.to_xml(indent: 2)
       #
       # Colorize tag, id/class name, and contents.
       #

--- a/lib/awesome_print/ext/sequel.rb
+++ b/lib/awesome_print/ext/sequel.rb
@@ -32,9 +32,7 @@ module AwesomePrint
         hash[c[0].to_sym] = c[1]
         hash
       end
-      if !object.errors.empty?
-        data = {:errors => object.errors, :values => data}
-      end
+      data = {errors: object.errors, values: data} if !object.errors.empty?
       "#{object} #{awesome_hash(data)}"
     end
 

--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -36,7 +36,7 @@ module AwesomePrint
           end
         end
 
-        data = limited(data, width, :hash => true) if should_be_limited?
+        data = limited(data, width, hash: true) if should_be_limited?
         if options[:multiline]
           "{\n" << data.join(",\n") << "\n#{outdent}}"
         else

--- a/spec/colors_spec.rb
+++ b/spec/colors_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe 'AwesomePrint' do
 
       it 'colorizes tty processes by default' do
         stub_tty!
-        expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
+        expect(@arr.ai(multiline: false)).to eq(COLORIZED)
       end
 
       it "colorizes processes with ENV['ANSICON'] by default" do
         begin
           stub_tty!
           term, ENV['ANSICON'] = ENV['ANSICON'], '1'
-          expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
+          expect(@arr.ai(multiline: false)).to eq(COLORIZED)
         ensure
           ENV['ANSICON'] = term
         end
@@ -43,7 +43,7 @@ RSpec.describe 'AwesomePrint' do
         begin
           stub_tty!
           term, ENV['TERM'] = ENV['TERM'], 'dumb'
-          expect(@arr.ai(:multiline => false)).to eq(PLAIN)
+          expect(@arr.ai(multiline: false)).to eq(PLAIN)
         ensure
           ENV['TERM'] = term
         end
@@ -52,7 +52,7 @@ RSpec.describe 'AwesomePrint' do
       it 'does not colorize subprocesses by default' do
         begin
           stub_tty! false
-          expect(@arr.ai(:multiline => false)).to eq(PLAIN)
+          expect(@arr.ai(multiline: false)).to eq(PLAIN)
         ensure
           stub_tty!
         end
@@ -66,14 +66,14 @@ RSpec.describe 'AwesomePrint' do
 
       it 'still colorizes tty processes' do
         stub_tty!
-        expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
+        expect(@arr.ai(multiline: false)).to eq(COLORIZED)
       end
 
       it "colorizes processes with ENV['ANSICON'] set to 0" do
         begin
           stub_tty!
           term, ENV['ANSICON'] = ENV['ANSICON'], '1'
-          expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
+          expect(@arr.ai(multiline: false)).to eq(COLORIZED)
         ensure
           ENV['ANSICON'] = term
         end
@@ -83,7 +83,7 @@ RSpec.describe 'AwesomePrint' do
         begin
           stub_tty!
           term, ENV['TERM'] = ENV['TERM'], 'dumb'
-          expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
+          expect(@arr.ai(multiline: false)).to eq(COLORIZED)
         ensure
           ENV['TERM'] = term
         end
@@ -92,7 +92,7 @@ RSpec.describe 'AwesomePrint' do
       it 'colorizes subprocess' do
         begin
           stub_tty! false
-          expect(@arr.ai(:multiline => false)).to eq(COLORIZED)
+          expect(@arr.ai(multiline: false)).to eq(COLORIZED)
         ensure
           stub_tty!
         end

--- a/spec/core_ext/logger_spec.rb
+++ b/spec/core_ext/logger_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'AwesomePrint logging extensions' do
       end
 
       it 'should use the global user default if no level passed' do
-        AwesomePrint.defaults = { :log_level => :info }
+        AwesomePrint.defaults = { log_level: :info }
         expect(@logger).to receive(:info)
         @logger.ap(nil)
       end

--- a/spec/ext/action_view_spec.rb
+++ b/spec/ext/action_view_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'AwesomePrint ActionView extensions', skip: ->{ !ExtVerifier.has_
 
   it "uses HTML and adds 'debug_dump' class to plain <pre> tag" do
     markup = rand
-    expect(@view.ap(markup, :plain => true)).to eq(%Q|<pre class="debug_dump">#{markup}</pre>|)
+    expect(@view.ap(markup, plain: true)).to eq(%Q|<pre class="debug_dump">#{markup}</pre>|)
   end
 
   it "uses HTML and adds 'debug_dump' class to colorized <pre> tag" do

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe 'AwesomePrint/ActiveRecord', skip: ->{ !ExtVerifier.has_rails? }.
   describe 'ActiveRecord instance, attributes only (default)' do
     before do
       ActiveRecord::Base.default_timezone = :utc
-      @diana = User.new(:name => 'Diana', :rank => 1, :admin => false, :created_at => '1992-10-10 12:30:00')
-      @laura = User.new(:name => 'Laura', :rank => 2, :admin => true,  :created_at => '2003-05-26 14:15:00')
-      @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true)
+      @diana = User.new(name: 'Diana', rank: 1, admin: false, created_at: '1992-10-10 12:30:00')
+      @laura = User.new(name: 'Laura', rank: 2, admin: true,  created_at: '2003-05-26 14:15:00')
+      @ap = AwesomePrint::Inspector.new(plain: true, sort_keys: true)
     end
 
     it 'display single record' do
@@ -94,11 +94,11 @@ RSpec.describe 'AwesomePrint/ActiveRecord', skip: ->{ !ExtVerifier.has_rails? }.
 
   describe 'Linked records (joins)' do
     before do
-      @ap = AwesomePrint::Inspector.new(:plain => true)
+      @ap = AwesomePrint::Inspector.new(plain: true)
     end
 
     it 'should show the entire record' do
-      e = Email.create(:email_address => 'foo@bar.com')
+      e = Email.create(email_address: 'foo@bar.com')
       u = User.last
       u.emails << e
       email_record = User.joins(:emails).select('users.id, emails.email_address').last
@@ -117,9 +117,9 @@ EOS
   describe 'ActiveRecord instance (raw)' do
     before do
       ActiveRecord::Base.default_timezone = :utc
-      @diana = User.new(:name => 'Diana', :rank => 1, :admin => false, :created_at => '1992-10-10 12:30:00')
-      @laura = User.new(:name => 'Laura', :rank => 2, :admin => true,  :created_at => '2003-05-26 14:15:00')
-      @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true, :raw => true)
+      @diana = User.new(name: 'Diana', rank: 1, admin: false, created_at: '1992-10-10 12:30:00')
+      @laura = User.new(name: 'Laura', rank: 2, admin: true,  created_at: '2003-05-26 14:15:00')
+      @ap = AwesomePrint::Inspector.new(plain: true, sort_keys: true, raw: true)
     end
 
     it 'display single record' do
@@ -181,7 +181,7 @@ EOS
   #------------------------------------------------------------------------------
   describe 'ActiveRecord class' do
     before do
-      @ap = AwesomePrint::Inspector.new(:plain => true)
+      @ap = AwesomePrint::Inspector.new(plain: true)
     end
 
     it 'should print the class' do
@@ -217,7 +217,7 @@ class SubUser < User {
   #------------------------------------------------------------------------------
   describe 'ActiveRecord methods formatting' do
     before do
-      @ap = AwesomePrint::Inspector.new(:plain => true)
+      @ap = AwesomePrint::Inspector.new(plain: true)
     end
 
     it 'should format class methods properly' do

--- a/spec/ext/active_support_spec.rb
+++ b/spec/ext/active_support_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'AwesomePrint::ActiveSupport', skip: ->{ !ExtVerifier.has_rails? 
   end
 
   it 'should format HashWithIndifferentAccess as regular Hash' do
-    hash = HashWithIndifferentAccess.new({ :hello => 'world' })
+    hash = HashWithIndifferentAccess.new({ hello: 'world' })
     expect(@ap.send(:awesome, hash)).to eq("{\n    \"hello\"\e[0;37m => \e[0m\e[0;33m\"world\"\e[0m\n}")
   end
 
@@ -20,7 +20,7 @@ RSpec.describe 'AwesomePrint::ActiveSupport', skip: ->{ !ExtVerifier.has_rails? 
   # we ignore that and format Date instance as regular date.
   it 'should formate Date object as date' do
     date = Date.new(2003, 5, 26)
-    expect(date.ai(:plain => true)).to eq('Mon, 26 May 2003')
+    expect(date.ai(plain: true)).to eq('Mon, 26 May 2003')
     expect(date.ai).to eq("\e[0;32mMon, 26 May 2003\e[0m")
   end
 end

--- a/spec/ext/mongo_mapper_spec.rb
+++ b/spec/ext/mongo_mapper_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe 'AwesomePrint/MongoMapper', skip: ->{ !ExtVerifier.has_mongo_mapp
   end
 
   before do
-    @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true)
+    @ap = AwesomePrint::Inspector.new(plain: true, sort_keys: true)
   end
 
   describe 'with the raw option set to true' do
     # before { @ap.options[:raw] = true }
-    before { @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true, :raw => true) }
+    before { @ap = AwesomePrint::Inspector.new(plain: true, sort_keys: true, raw: true) }
 
     it 'should print class instance' do
-      user = MongoUser.new(:first_name => 'Al', :last_name => 'Capone')
+      user = MongoUser.new(first_name: 'Al', last_name: 'Capone')
 
       out = @ap.send(:awesome, user)
       out.gsub!(/#\<Proc:.+?\>/, 'AWESOME_PRINT_PROC_STUB')
@@ -187,7 +187,7 @@ class Parent < Object {
       end
 
       it 'should render an instance as normal' do
-        parent = Parent.new(:name => 'test')
+        parent = Parent.new(name: 'test')
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
 #<Parent:placeholder_id> {
@@ -201,7 +201,7 @@ class Parent < Object {
 
     describe 'with show associations turned on and inline embedded turned off' do
       before :each do
-        @ap = AwesomePrint::Inspector.new(:plain => true, :mongo_mapper => { :show_associations => true })
+        @ap = AwesomePrint::Inspector.new(plain: true, mongo_mapper: { show_associations: true })
       end
 
       it 'should render the class with associations shown' do
@@ -216,7 +216,7 @@ class Parent < Object {
       end
 
       it 'should render an instance with associations shown' do
-        parent = Parent.new(:name => 'test')
+        parent = Parent.new(name: 'test')
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
 #<Parent:placeholder_id> {
@@ -232,16 +232,16 @@ class Parent < Object {
 
     describe 'with show associations turned on and inline embedded turned on' do
       before :each do
-        @ap = AwesomePrint::Inspector.new(:plain => true,
-                                          :mongo_mapper => {
-          :show_associations => true,
-          :inline_embedded   => true
+        @ap = AwesomePrint::Inspector.new(plain: true,
+                                          mongo_mapper: {
+          show_associations: true,
+          inline_embedded: true
         }
                                          )
       end
 
       it 'should render an instance with associations shown and embeds there' do
-        parent = Parent.new(:name => 'test', :child => Child.new(:data => 5))
+        parent = Parent.new(name: 'test', child: Child.new(data: 5))
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
 #<Parent:placeholder_id> {

--- a/spec/ext/mongoid_spec.rb
+++ b/spec/ext/mongoid_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'AwesomePrint/Mongoid', skip: ->{ !ExtVerifier.has_mongoid? }.cal
       class MongoUser
         include Mongoid::Document
 
-        field :first_name, :type => String
-        field :last_name,  :type => String
+        field :first_name, type: String
+        field :last_name,  type: String
       end
     end
 
@@ -19,11 +19,11 @@ RSpec.describe 'AwesomePrint/Mongoid', skip: ->{ !ExtVerifier.has_mongoid? }.cal
   end
 
   before do
-    @ap = AwesomePrint::Inspector.new :plain => true, :sort_keys => true
+    @ap = AwesomePrint::Inspector.new plain: true, sort_keys: true
   end
 
   it 'should print class instance' do
-    user = MongoUser.new :first_name => 'Al', :last_name => 'Capone'
+    user = MongoUser.new first_name: 'Al', last_name: 'Capone'
     out = @ap.send :awesome, user
 
     object_id = user.id.inspect
@@ -34,7 +34,7 @@ RSpec.describe 'AwesomePrint/Mongoid', skip: ->{ !ExtVerifier.has_mongoid? }.cal
      :last_name => "Capone"
 }
     EOS
-    expect(out).to be_similar_to(str, {:skip_bson => true})
+    expect(out).to be_similar_to(str, {skip_bson: true})
   end
 
   it 'should print the class' do

--- a/spec/ext/nobrainer_spec.rb
+++ b/spec/ext/nobrainer_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'AwesomePrint/NoBrainer', skip: ->{ !ExtVerifier.has_nobrainer? }
       class SomeModel
         include NoBrainer::Document
 
-        field :first_name, :type => String
-        field :last_name,  :type => String
+        field :first_name, type: String
+        field :last_name,  type: String
         field :some_field
       end
     end
@@ -26,11 +26,11 @@ RSpec.describe 'AwesomePrint/NoBrainer', skip: ->{ !ExtVerifier.has_nobrainer? }
   end
 
   before do
-    @ap = AwesomePrint::Inspector.new :plain => true
+    @ap = AwesomePrint::Inspector.new plain: true
   end
 
   it 'should print class instance' do
-    user = SomeModel.new :first_name => 'Al', :last_name => 'Capone'
+    user = SomeModel.new first_name: 'Al', last_name: 'Capone'
     out = @ap.send :awesome, user
 
     object_id = user.id.inspect

--- a/spec/ext/ostruct_spec.rb
+++ b/spec/ext/ostruct_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'AwesomePrint Ostruct extension' do
   before do
-    @ap = AwesomePrint::Inspector.new(:plain => true, :sort_keys => true)
+    @ap = AwesomePrint::Inspector.new(plain: true, sort_keys: true)
   end
 
   it 'empty hash' do
@@ -11,7 +11,7 @@ RSpec.describe 'AwesomePrint Ostruct extension' do
   end
 
   it 'plain multiline' do
-    struct = OpenStruct.new :name => 'Foo', :address => 'Bar'
+    struct = OpenStruct.new name: 'Foo', address: 'Bar'
     expect(@ap.send(:awesome, struct)).to eq <<-EOS.strip
 OpenStruct {
     :address => "Bar",

--- a/spec/ext/ripple_spec.rb
+++ b/spec/ext/ripple_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'AwesomePrint/Ripple', skip: ->{ !ExtVerifier.has_ripple? }.call 
   end
 
   before do
-    @ap = AwesomePrint::Inspector.new :plain => true, :sort_keys => true
+    @ap = AwesomePrint::Inspector.new plain: true, sort_keys: true
   end
 
   it 'should print class instance' do
-    user = RippleUser.new :_id => '12345', :first_name => 'Al', :last_name => 'Capone'
+    user = RippleUser.new _id: '12345', first_name: 'Al', last_name: 'Capone'
     out = @ap.send :awesome, user
 
     expect(out).to be_similar_to <<-EOS.strip

--- a/spec/formats_spec.rb
+++ b/spec/formats_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'AwesomePrint' do
     end
 
     it 'plain multiline' do
-      expect(@arr.ai(:plain => true)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true)).to eq <<-EOS.strip
 [
     [0] 1,
     [1] :two,
@@ -31,7 +31,7 @@ EOS
       end
 
     it 'plain multiline without index' do
-      expect(@arr.ai(:plain => true, :index => false)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, index: false)).to eq <<-EOS.strip
 [
     1,
     :two,
@@ -48,7 +48,7 @@ EOS
       end
 
     it 'plain multiline indented' do
-      expect(@arr.ai(:plain => true, :indent => 2)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, indent: 2)).to eq <<-EOS.strip
 [
   [0] 1,
   [1] :two,
@@ -65,7 +65,7 @@ EOS
     end
 
     it 'plain multiline indented without index' do
-      expect(@arr.ai(:plain => true, :indent => 2, :index => false)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, indent: 2, index: false)).to eq <<-EOS.strip
 [
   1,
   :two,
@@ -82,7 +82,7 @@ EOS
     end
 
     it 'plain single line' do
-      expect(@arr.ai(:plain => true, :multiline => false)).to eq('[ 1, :two, "three", [ nil, [ true, false ] ] ]')
+      expect(@arr.ai(plain: true, multiline: false)).to eq('[ 1, :two, "three", [ nil, [ true, false ] ] ]')
     end
 
     it 'colored multiline (default)' do
@@ -103,7 +103,7 @@ EOS
       end
 
     it 'colored multiline indented' do
-      expect(@arr.ai(:indent => 8)).to eq <<-EOS.strip
+      expect(@arr.ai(indent: 8)).to eq <<-EOS.strip
 [
         \e[1;37m[0] \e[0m\e[1;34m1\e[0m,
         \e[1;37m[1] \e[0m\e[0;36m:two\e[0m,
@@ -120,7 +120,7 @@ EOS
     end
 
     it 'colored single line' do
-      expect(@arr.ai(:multiline => false)).to eq("[ \e[1;34m1\e[0m, \e[0;36m:two\e[0m, \e[0;33m\"three\"\e[0m, [ \e[1;31mnil\e[0m, [ \e[1;32mtrue\e[0m, \e[1;31mfalse\e[0m ] ] ]")
+      expect(@arr.ai(multiline: false)).to eq("[ \e[1;34m1\e[0m, \e[0;36m:two\e[0m, \e[0;33m\"three\"\e[0m, [ \e[1;31mnil\e[0m, [ \e[1;32mtrue\e[0m, \e[1;31mfalse\e[0m ] ] ]")
     end
   end
 
@@ -132,7 +132,7 @@ EOS
     end
 
     it 'plain multiline' do
-      expect(@arr.ai(:plain => true)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true)).to eq <<-EOS.strip
 [
     [0] 1,
     [1] 2,
@@ -142,7 +142,7 @@ EOS
     end
 
     it 'plain multiline without index' do
-      expect(@arr.ai(:plain => true, :index => false)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, index: false)).to eq <<-EOS.strip
 [
     1,
     2,
@@ -152,7 +152,7 @@ EOS
     end
 
     it 'plain single line' do
-      expect(@arr.ai(:plain => true, :multiline => false)).to eq('[ 1, 2, [...] ]')
+      expect(@arr.ai(plain: true, multiline: false)).to eq('[ 1, 2, [...] ]')
     end
   end
 
@@ -163,7 +163,7 @@ EOS
     end
 
     it 'plain limited output large' do
-      expect(@arr.ai(:plain => true, :limit => true)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, limit: true)).to eq <<-EOS.strip
 [
     [  0] 1,
     [  1] 2,
@@ -178,7 +178,7 @@ EOS
 
     it 'plain limited output small' do
       @arr = @arr[0..3]
-      expect(@arr.ai(:plain => true, :limit => true)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, limit: true)).to eq <<-EOS.strip
 [
     [0] 1,
     [1] 2,
@@ -189,7 +189,7 @@ EOS
     end
 
     it 'plain limited output with 10 lines' do
-      expect(@arr.ai(:plain => true, :limit => 10)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, limit: 10)).to eq <<-EOS.strip
 [
     [  0] 1,
     [  1] 2,
@@ -206,7 +206,7 @@ EOS
     end
 
     it 'plain limited output with 11 lines' do
-      expect(@arr.ai(:plain => true, :limit => 11)).to eq <<-EOS.strip
+      expect(@arr.ai(plain: true, limit: 11)).to eq <<-EOS.strip
 [
     [  0] 1,
     [  1] 2,
@@ -231,7 +231,7 @@ EOS
     end
 
     it 'plain limited output' do
-      expect(@hash.ai(:sort_keys => true, :plain => true, :limit => true)).to eq <<-EOS.strip
+      expect(@hash.ai(sort_keys: true, plain: true, limit: true)).to eq <<-EOS.strip
 {
     "a" => :a,
     "b" => :b,
@@ -248,7 +248,7 @@ EOS
   #------------------------------------------------------------------------------
   describe 'Hash' do
     before do
-      @hash = { 1 => { :sym => { 'str' => { [1, 2, 3] => { { :k => :v } => Hash } } } } }
+      @hash = { 1 => { sym: { 'str' => { [1, 2, 3] => { { k: :v } => Hash } } } } }
     end
 
     it 'empty hash' do
@@ -256,7 +256,7 @@ EOS
     end
 
     it 'plain multiline' do
-      expect(@hash.ai(:plain => true)).to eq <<-EOS.strip
+      expect(@hash.ai(plain: true)).to eq <<-EOS.strip
 {
     1 => {
         :sym => {
@@ -272,7 +272,7 @@ EOS
     end
 
     it 'new hash syntax' do
-      expect(@hash.ai(:plain => true, :ruby19_syntax => true)).to eq <<-EOS.strip
+      expect(@hash.ai(plain: true, ruby19_syntax: true)).to eq <<-EOS.strip
 {
     1 => {
         sym: {
@@ -288,7 +288,7 @@ EOS
     end
 
     it 'plain multiline indented' do
-      expect(@hash.ai(:plain => true, :indent => 1)).to eq <<-EOS.strip
+      expect(@hash.ai(plain: true, indent: 1)).to eq <<-EOS.strip
 {
  1 => {
   :sym => {
@@ -304,7 +304,7 @@ EOS
     end
 
     it 'plain single line' do
-      expect(@hash.ai(:plain => true, :multiline => false)).to eq('{ 1 => { :sym => { "str" => { [ 1, 2, 3 ] => { { :k => :v } => Hash < Object } } } } }')
+      expect(@hash.ai(plain: true, multiline: false)).to eq('{ 1 => { :sym => { "str" => { [ 1, 2, 3 ] => { { :k => :v } => Hash < Object } } } } }')
     end
 
     it 'colored multiline (default)' do
@@ -324,7 +324,7 @@ EOS
     end
 
     it 'colored with new hash syntax' do
-      expect(@hash.ai(:ruby19_syntax => true)).to eq <<-EOS.strip
+      expect(@hash.ai(ruby19_syntax: true)).to eq <<-EOS.strip
 {
     1\e[0;37m => \e[0m{
         sym\e[0;37m: \e[0m{
@@ -340,7 +340,7 @@ EOS
     end
 
     it 'colored multiline indented' do
-      expect(@hash.ai(:indent => 2)).to eq <<-EOS.strip
+      expect(@hash.ai(indent: 2)).to eq <<-EOS.strip
 {
   1\e[0;37m => \e[0m{
     :sym\e[0;37m => \e[0m{
@@ -356,7 +356,7 @@ EOS
     end
 
     it 'colored single line' do
-      expect(@hash.ai(:multiline => false)).to eq("{ 1\e[0;37m => \e[0m{ :sym\e[0;37m => \e[0m{ \"str\"\e[0;37m => \e[0m{ [ 1, 2, 3 ]\e[0;37m => \e[0m{ { :k => :v }\e[0;37m => \e[0m\e[1;33mHash < Object\e[0m } } } } }")
+      expect(@hash.ai(multiline: false)).to eq("{ 1\e[0;37m => \e[0m{ :sym\e[0;37m => \e[0m{ \"str\"\e[0;37m => \e[0m{ [ 1, 2, 3 ]\e[0;37m => \e[0m{ { :k => :v }\e[0;37m => \e[0m\e[1;33mHash < Object\e[0m } } } } }")
     end
 
   end
@@ -369,7 +369,7 @@ EOS
     end
 
     it 'plain multiline' do
-      expect(@hash.ai(:plain => true)).to eq <<-EOS.strip
+      expect(@hash.ai(plain: true)).to eq <<-EOS.strip
 {
     :a => {...}
 }
@@ -377,7 +377,7 @@ EOS
     end
 
     it 'plain single line' do
-      expect(@hash.ai(:plain => true, :multiline => false)).to eq('{ :a => {...} }')
+      expect(@hash.ai(plain: true, multiline: false)).to eq('{ :a => {...} }')
     end
   end
 
@@ -388,7 +388,7 @@ EOS
     end
 
     it 'plain multiline' do
-      out = @hash.ai(:plain => true)
+      out = @hash.ai(plain: true)
       if RUBY_VERSION.to_f < 1.9 # Order of @hash keys is not guaranteed.
         expect(out).to match(/^\{[^\}]+\}/m)
         expect(out).to match(/        "b" => "b",?/)
@@ -408,7 +408,7 @@ EOS
     end
 
     it 'plain multiline with sorted keys' do
-      expect(@hash.ai(:plain => true, :sort_keys => true)).to eq <<-EOS.strip
+      expect(@hash.ai(plain: true, sort_keys: true)).to eq <<-EOS.strip
 {
          :a => "a",
     "alpha" => "alpha",
@@ -428,7 +428,7 @@ EOS
     #
     it 'hash keys must be left aligned' do
       hash = { [0, 0, 255] => :yellow, :red => 'rgb(255, 0, 0)', 'magenta' => 'rgb(255, 0, 255)' }
-      out = hash.ai(:plain => true, :indent => -4, :sort_keys => true)
+      out = hash.ai(plain: true, indent: -4, sort_keys: true)
       expect(out).to eq <<-EOS.strip
 {
     [ 0, 0, 255 ] => :yellow,
@@ -439,8 +439,8 @@ EOS
     end
 
     it 'nested hash keys should be indented (array of hashes)' do
-      arr = [ { :a => 1, :bb => 22, :ccc => 333}, { 1 => :a, 22 => :bb, 333 => :ccc} ]
-      out = arr.ai(:plain => true, :indent => -4, :sort_keys => true)
+      arr = [ { a: 1, bb: 22, ccc: 333}, { 1 => :a, 22 => :bb, 333 => :ccc} ]
+      out = arr.ai(plain: true, indent: -4, sort_keys: true)
       expect(out).to eq <<-EOS.strip
 [
     [0] {
@@ -458,8 +458,8 @@ EOS
     end
 
     it 'nested hash keys should be indented (hash of hashes)' do
-      arr = { :first => { :a => 1, :bb => 22, :ccc => 333}, :second => { 1 => :a, 22 => :bb, 333 => :ccc} }
-      out = arr.ai(:plain => true, :indent => -4, :sort_keys => true)
+      arr = { first: { a: 1, bb: 22, ccc: 333}, second: { 1 => :a, 22 => :bb, 333 => :ccc} }
+      out = arr.ai(plain: true, indent: -4, sort_keys: true)
       expect(out).to eq <<-EOS.strip
 {
     :first  => {
@@ -480,7 +480,7 @@ EOS
   #------------------------------------------------------------------------------
   describe 'Class' do
     it 'should show superclass (plain)' do
-      expect(self.class.ai(:plain => true)).to eq("#{self.class} < #{self.class.superclass}")
+      expect(self.class.ai(plain: true)).to eq("#{self.class} < #{self.class.superclass}")
     end
 
     it 'should show superclass (color)' do
@@ -492,7 +492,7 @@ EOS
   describe 'File' do
     it 'should display a file (plain)' do
       File.open(__FILE__, 'r') do |f|
-        expect(f.ai(:plain => true)).to eq("#{f.inspect}\n" << `ls -alF #{f.path}`.chop)
+        expect(f.ai(plain: true)).to eq("#{f.inspect}\n" << `ls -alF #{f.path}`.chop)
       end
     end
   end
@@ -501,7 +501,7 @@ EOS
   describe 'Dir' do
     it 'should display a direcory (plain)' do
       Dir.open(File.dirname(__FILE__)) do |d|
-        expect(d.ai(:plain => true)).to eq("#{d.inspect}\n" << `ls -alF #{d.path}`.chop)
+        expect(d.ai(plain: true)).to eq("#{d.inspect}\n" << `ls -alF #{d.path}`.chop)
       end
     end
   end
@@ -510,12 +510,12 @@ EOS
   describe 'BigDecimal and Rational' do
     it 'should present BigDecimal object with arbitrary precision' do
       big = BigDecimal('201020102010201020102010201020102010.4')
-      expect(big.ai(:plain => true)).to eq('201020102010201020102010201020102010.4')
+      expect(big.ai(plain: true)).to eq('201020102010201020102010201020102010.4')
     end
 
     it 'should present Rational object with arbitrary precision' do
       rat = Rational(201020102010201020102010201020102010, 2)
-      out = rat.ai(:plain => true)
+      out = rat.ai(plain: true)
       #
       # Ruby 1.9 slightly changed the format of Rational#to_s, see
       # http://techtime.getharvest.com/blog/harvest-is-now-on-ruby-1-dot-9-3 and
@@ -533,7 +533,7 @@ EOS
   describe 'Utility methods' do
     it 'should merge options' do
       ap = AwesomePrint::Inspector.new
-      ap.send(:merge_options!, { :color => { :array => :black }, :indent => 0 })
+      ap.send(:merge_options!, { color: { array: :black }, indent: 0 })
       options = ap.instance_variable_get('@options')
       expect(options[:color][:array]).to eq(:black)
       expect(options[:indent]).to eq(0)
@@ -553,15 +553,15 @@ EOS
 
     if RUBY_VERSION > '1.9'
       it 'plain multiline' do
-        expect(@set.ai(:plain => true)).to eq(@arr.ai(:plain => true))
+        expect(@set.ai(plain: true)).to eq(@arr.ai(plain: true))
       end
 
       it 'plain multiline indented' do
-        expect(@set.ai(:plain => true, :indent => 1)).to eq(@arr.ai(:plain => true, :indent => 1))
+        expect(@set.ai(plain: true, indent: 1)).to eq(@arr.ai(plain: true, indent: 1))
       end
 
       it 'plain single line' do
-        expect(@set.ai(:plain => true, :multiline => false)).to eq(@arr.ai(:plain => true, :multiline => false))
+        expect(@set.ai(plain: true, multiline: false)).to eq(@arr.ai(plain: true, multiline: false))
       end
 
       it 'colored multiline (default)' do
@@ -569,15 +569,15 @@ EOS
       end
     else # Prior to Ruby 1.9 the order of set values is unpredicatble.
       it 'plain multiline' do
-        expect(@set.sort_by{ |x| x.to_s }.ai(:plain => true)).to eq(@arr.sort_by{ |x| x.to_s }.ai(:plain => true))
+        expect(@set.sort_by{ |x| x.to_s }.ai(plain: true)).to eq(@arr.sort_by{ |x| x.to_s }.ai(plain: true))
       end
 
       it 'plain multiline indented' do
-        expect(@set.sort_by{ |x| x.to_s }.ai(:plain => true, :indent => 1)).to eq(@arr.sort_by{ |x| x.to_s }.ai(:plain => true, :indent => 1))
+        expect(@set.sort_by{ |x| x.to_s }.ai(plain: true, indent: 1)).to eq(@arr.sort_by{ |x| x.to_s }.ai(plain: true, indent: 1))
       end
 
       it 'plain single line' do
-        expect(@set.sort_by{ |x| x.to_s }.ai(:plain => true, :multiline => false)).to eq(@arr.sort_by{ |x| x.to_s }.ai(:plain => true, :multiline => false))
+        expect(@set.sort_by{ |x| x.to_s }.ai(plain: true, multiline: false)).to eq(@arr.sort_by{ |x| x.to_s }.ai(plain: true, multiline: false))
       end
 
       it 'colored multiline (default)' do
@@ -611,7 +611,7 @@ EOS
     name = \"Herman Munster\",
     address = \"1313 Mockingbird Lane\"
 EOS
-      expect(@struct.ai(:plain => true)).to satisfy { |out| out.match(s1) || out.match(s2) }
+      expect(@struct.ai(plain: true)).to satisfy { |out| out.match(s1) || out.match(s2) }
     end
 
     it 'plain multiline indented' do
@@ -623,13 +623,13 @@ EOS
  name = "Herman Munster",
  address = "1313 Mockingbird Lane"
 EOS
-      expect(@struct.ai(:plain => true, :indent => 1)).to satisfy { |out| out.match(s1) || out.match(s2) }
+      expect(@struct.ai(plain: true, indent: 1)).to satisfy { |out| out.match(s1) || out.match(s2) }
     end
 
     it 'plain single line' do
       s1 = 'address = "1313 Mockingbird Lane", name = "Herman Munster"'
       s2 = 'name = "Herman Munster", address = "1313 Mockingbird Lane"'
-      expect(@struct.ai(:plain => true, :multiline => false)).to satisfy { |out| out.match(s1) || out.match(s2) }
+      expect(@struct.ai(plain: true, multiline: false)).to satisfy { |out| out.match(s1) || out.match(s2) }
     end
 
     it 'colored multiline (default)' do
@@ -655,7 +655,7 @@ EOS
       class My < Array; end
 
       my = My.new([ 1, :two, 'three', [ nil, [ true, false ] ] ])
-      expect(my.ai(:plain => true)).to eq <<-EOS.strip
+      expect(my.ai(plain: true)).to eq <<-EOS.strip
 [
     [0] 1,
     [1] :two,
@@ -674,8 +674,8 @@ EOS
     it 'inherited from Hash should be displayed as Hash' do
       class My < Hash; end
 
-      my = My[ { 1 => { :sym => { 'str' => { [1, 2, 3] => { { :k => :v } => Hash } } } } } ]
-      expect(my.ai(:plain => true)).to eq <<-EOS.strip
+      my = My[ { 1 => { sym: { 'str' => { [1, 2, 3] => { { k: :v } => Hash } } } } } ]
+      expect(my.ai(plain: true)).to eq <<-EOS.strip
 {
     1 => {
         :sym => {
@@ -694,7 +694,7 @@ EOS
       class My < File; end
 
       my = File.new('/dev/null') rescue File.new('nul')
-      expect(my.ai(:plain => true)).to eq("#{my.inspect}\n" << `ls -alF #{my.path}`.chop)
+      expect(my.ai(plain: true)).to eq("#{my.inspect}\n" << `ls -alF #{my.path}`.chop)
     end
 
     it 'inherited from Dir should be displayed as Dir' do
@@ -702,7 +702,7 @@ EOS
 
       require 'tmpdir'
       my = My.new(Dir.tmpdir)
-      expect(my.ai(:plain => true)).to eq("#{my.inspect}\n" << `ls -alF #{my.path}`.chop)
+      expect(my.ai(plain: true)).to eq("#{my.inspect}\n" << `ls -alF #{my.path}`.chop)
     end
 
     it 'should handle a class that defines its own #send method' do
@@ -711,7 +711,7 @@ EOS
       end
 
       my = My.new
-      expect { my.methods.ai(:plain => true) }.not_to raise_error
+      expect { my.methods.ai(plain: true) }.not_to raise_error
     end
 
     it 'should handle a class defines its own #method method (ex. request.method)' do
@@ -722,7 +722,7 @@ EOS
       end
 
       my = My.new
-      expect { my.methods.ai(:plain => true) }.not_to raise_error
+      expect { my.methods.ai(plain: true) }.not_to raise_error
     end
 
     describe 'should handle a class that defines its own #to_hash method' do
@@ -733,7 +733,7 @@ EOS
         end
 
         my = My.new
-        expect { my.ai(:plain => true) }.not_to raise_error
+        expect { my.ai(plain: true) }.not_to raise_error
       end
 
       it 'that returns nil' do
@@ -744,7 +744,7 @@ EOS
         end
 
         my = My.new
-        expect { my.ai(:plain => true) }.not_to raise_error
+        expect { my.ai(plain: true) }.not_to raise_error
       end
 
       it "that returns an object that doesn't support #keys" do
@@ -758,7 +758,7 @@ EOS
         end
 
         my = My.new
-        expect { my.ai(:plain => true) }.not_to raise_error
+        expect { my.ai(plain: true) }.not_to raise_error
       end
 
       it "that returns an object that doesn't support subscripting" do
@@ -772,7 +772,7 @@ EOS
         end
 
         my = My.new
-        expect { my.ai(:plain => true) }.not_to raise_error
+        expect { my.ai(plain: true) }.not_to raise_error
       end
     end
   end

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Single method' do
 
   it 'plain: should handle a method with no arguments' do
     method = ''.method(:upcase)
-    expect(method.ai(:plain => true)).to eq('String#upcase()')
+    expect(method.ai(plain: true)).to eq('String#upcase()')
   end
 
   it 'color: should handle a method with no arguments' do
@@ -17,7 +17,7 @@ RSpec.describe 'Single method' do
 
   it 'plain: should handle a method with one argument' do
     method = ''.method(:include?)
-    expect(method.ai(:plain => true)).to eq('String#include?(arg1)')
+    expect(method.ai(plain: true)).to eq('String#include?(arg1)')
   end
 
   it 'color: should handle a method with one argument' do
@@ -27,7 +27,7 @@ RSpec.describe 'Single method' do
 
   it 'plain: should handle a method with two arguments' do
     method = ''.method(:tr)
-    expect(method.ai(:plain => true)).to eq('String#tr(arg1, arg2)')
+    expect(method.ai(plain: true)).to eq('String#tr(arg1, arg2)')
   end
 
   it 'color: should handle a method with two arguments' do
@@ -37,7 +37,7 @@ RSpec.describe 'Single method' do
 
   it 'plain: should handle a method with multiple arguments' do
     method = ''.method(:split)
-    expect(method.ai(:plain => true)).to eq('String#split(*arg1)')
+    expect(method.ai(plain: true)).to eq('String#split(*arg1)')
   end
 
   it 'color: should handle a method with multiple arguments' do
@@ -47,7 +47,7 @@ RSpec.describe 'Single method' do
 
   it 'plain: should handle a method defined in mixin' do
     method = ''.method(:is_a?)
-    expect(method.ai(:plain => true)).to eq('String (Kernel)#is_a?(arg1)')
+    expect(method.ai(plain: true)).to eq('String (Kernel)#is_a?(arg1)')
   end
 
   it 'color: should handle a method defined in mixin' do
@@ -60,7 +60,7 @@ RSpec.describe 'Single method' do
       def world; end
     end
     method = Hello.instance_method(:world)
-    expect(method.ai(:plain => true)).to eq('Hello (unbound)#world()')
+    expect(method.ai(plain: true)).to eq('Hello (unbound)#world()')
   end
 
   it 'color: should handle an unbound method' do
@@ -83,36 +83,36 @@ RSpec.describe 'Object methods' do
 
   describe 'object.methods' do
     it 'index: should handle object.methods' do
-      out = nil.methods.ai(:plain => true).split("\n").grep(/is_a\?/).first
+      out = nil.methods.ai(plain: true).split("\n").grep(/is_a\?/).first
       expect(out).to match(/^\s+\[\s*\d+\]\s+is_a\?\(arg1\)\s+NilClass \(Kernel\)$/)
     end
 
     it 'no index: should handle object.methods' do
-      out = nil.methods.ai(:plain => true, :index => false).split("\n").grep(/is_a\?/).first
+      out = nil.methods.ai(plain: true, index: false).split("\n").grep(/is_a\?/).first
       expect(out).to match(/^\s+is_a\?\(arg1\)\s+NilClass \(Kernel\)$/)
     end
   end
 
   describe 'object.public_methods' do
     it 'index: should handle object.public_methods' do
-      out = nil.public_methods.ai(:plain => true).split("\n").grep(/is_a\?/).first
+      out = nil.public_methods.ai(plain: true).split("\n").grep(/is_a\?/).first
       expect(out).to match(/^\s+\[\s*\d+\]\s+is_a\?\(arg1\)\s+NilClass \(Kernel\)$/)
     end
 
     it 'no index: should handle object.public_methods' do
-      out = nil.public_methods.ai(:plain => true, :index => false).split("\n").grep(/is_a\?/).first
+      out = nil.public_methods.ai(plain: true, index: false).split("\n").grep(/is_a\?/).first
       expect(out).to match(/^\s+is_a\?\(arg1\)\s+NilClass \(Kernel\)$/)
     end
   end
 
   describe 'object.private_methods' do
     it 'index: should handle object.private_methods' do
-      out = nil.private_methods.ai(:plain => true).split("\n").grep(/sleep/).first
+      out = nil.private_methods.ai(plain: true).split("\n").grep(/sleep/).first
       expect(out).to match(/^\s+\[\s*\d+\]\s+sleep\(\*arg1\)\s+NilClass \(Kernel\)$/)
     end
 
     it 'no index: should handle object.private_methods' do
-      out = nil.private_methods.ai(:plain => true, :index => false).split("\n").grep(/sleep/).first
+      out = nil.private_methods.ai(plain: true, index: false).split("\n").grep(/sleep/).first
       expect(out).to match(/^\s+sleep\(\*arg1\)\s+NilClass \(Kernel\)$/)
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe 'Object methods' do
         def m1; end
         def m2; end
       end
-      expect(Hello.new.protected_methods.ai(:plain => true)).to eq("[\n    [0] m1() Hello\n    [1] m2() Hello\n]")
+      expect(Hello.new.protected_methods.ai(plain: true)).to eq("[\n    [0] m1() Hello\n    [1] m2() Hello\n]")
     end
 
     it 'no index: should handle object.protected_methods' do
@@ -133,9 +133,9 @@ RSpec.describe 'Object methods' do
         def m3(a,b); end
       end
       if RUBY_VERSION < '1.9.2'
-        expect(Hello.new.protected_methods.ai(:plain => true, :index => false)).to eq("[\n     m3(arg1, arg2) Hello\n]")
+        expect(Hello.new.protected_methods.ai(plain: true, index: false)).to eq("[\n     m3(arg1, arg2) Hello\n]")
       else
-        expect(Hello.new.protected_methods.ai(:plain => true, :index => false)).to eq("[\n     m3(a, b) Hello\n]")
+        expect(Hello.new.protected_methods.ai(plain: true, index: false)).to eq("[\n     m3(a, b) Hello\n]")
       end
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe 'Object methods' do
         def m2; end
       end
 
-      out = Hello.new.private_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.new.private_methods.ai(plain: true).split("\n").grep(/m\d/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello$/)
       expect(out.last).to  match(/^\s+\[\s*\d+\]\s+m2\(\)\s+Hello$/)
     end
@@ -158,7 +158,7 @@ RSpec.describe 'Object methods' do
         private
         def m3(a,b); end
       end
-      out = Hello.new.private_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.new.private_methods.ai(plain: true).split("\n").grep(/m\d/)
       if RUBY_VERSION < '1.9.2'
         expect(out.first).to match(/^\s+\[\s*\d+\]\s+m3\(arg1, arg2\)\s+Hello$/)
       else
@@ -175,7 +175,7 @@ RSpec.describe 'Object methods' do
           def m2; end
         end
       end
-      out = Hello.singleton_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.singleton_methods.ai(plain: true).split("\n").grep(/m\d/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello$/)
       expect(out.last).to  match(/^\s+\[\s*\d+\]\s+m2\(\)\s+Hello$/)
     end
@@ -184,7 +184,7 @@ RSpec.describe 'Object methods' do
       class Hello
         def self.m3(a,b); end
       end
-      out = Hello.singleton_methods.ai(:plain => true, :index => false).split("\n").grep(/m\d/)
+      out = Hello.singleton_methods.ai(plain: true, index: false).split("\n").grep(/m\d/)
       if RUBY_VERSION < '1.9.2'
         expect(out.first).to match(/^\s+m3\(arg1, arg2\)\s+Hello$/)
       else
@@ -205,7 +205,7 @@ RSpec.describe 'Class methods' do
         def m1; end
         def m2; end
       end
-      out = Hello.instance_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.instance_methods.ai(plain: true).split("\n").grep(/m\d/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello\s\(unbound\)$/)
       expect(out.last).to  match(/^\s+\[\s*\d+\]\s+m2\(\)\s+Hello\s\(unbound\)$/)
     end
@@ -214,7 +214,7 @@ RSpec.describe 'Class methods' do
       class Hello
         def m3(a,b); end
       end
-      out = Hello.instance_methods.ai(:plain => true, :index => false).split("\n").grep(/m\d/)
+      out = Hello.instance_methods.ai(plain: true, index: false).split("\n").grep(/m\d/)
       if RUBY_VERSION < '1.9.2'
         expect(out.first).to match(/^\s+m3\(arg1, arg2\)\s+Hello\s\(unbound\)$/)
       else
@@ -229,7 +229,7 @@ RSpec.describe 'Class methods' do
         def m1; end
         def m2; end
       end
-      out = Hello.public_instance_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.public_instance_methods.ai(plain: true).split("\n").grep(/m\d/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello\s\(unbound\)$/)
       expect(out.last).to  match(/^\s+\[\s*\d+\]\s+m2\(\)\s+Hello\s\(unbound\)$/)
     end
@@ -238,7 +238,7 @@ RSpec.describe 'Class methods' do
       class Hello
         def m3(a,b); end
       end
-      out = Hello.public_instance_methods.ai(:plain => true, :index => false).split("\n").grep(/m\d/)
+      out = Hello.public_instance_methods.ai(plain: true, index: false).split("\n").grep(/m\d/)
       if RUBY_VERSION < '1.9.2'
         expect(out.first).to match(/^\s+m3\(arg1, arg2\)\s+Hello\s\(unbound\)$/)
       else
@@ -254,7 +254,7 @@ RSpec.describe 'Class methods' do
         def m1; end
         def m2; end
       end
-      out = Hello.protected_instance_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.protected_instance_methods.ai(plain: true).split("\n").grep(/m\d/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello\s\(unbound\)$/)
       expect(out.last).to  match(/^\s+\[\s*\d+\]\s+m2\(\)\s+Hello\s\(unbound\)$/)
     end
@@ -264,7 +264,7 @@ RSpec.describe 'Class methods' do
         protected
         def m3(a,b); end
       end
-      out = Hello.protected_instance_methods.ai(:plain => true, :index => false).split("\n").grep(/m\d/)
+      out = Hello.protected_instance_methods.ai(plain: true, index: false).split("\n").grep(/m\d/)
       if RUBY_VERSION < '1.9.2'
         expect(out.first).to match(/^\s+m3\(arg1, arg2\)\s+Hello\s\(unbound\)$/)
       else
@@ -280,7 +280,7 @@ RSpec.describe 'Class methods' do
         def m1; end
         def m2; end
       end
-      out = Hello.private_instance_methods.ai(:plain => true).split("\n").grep(/m\d/)
+      out = Hello.private_instance_methods.ai(plain: true).split("\n").grep(/m\d/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello\s\(unbound\)$/)
       expect(out.last).to  match(/^\s+\[\s*\d+\]\s+m2\(\)\s+Hello\s\(unbound\)$/)
     end
@@ -290,7 +290,7 @@ RSpec.describe 'Class methods' do
         private
         def m3(a,b); end
       end
-      out = Hello.private_instance_methods.ai(:plain => true, :index => false).split("\n").grep(/m\d/)
+      out = Hello.private_instance_methods.ai(plain: true, index: false).split("\n").grep(/m\d/)
       if RUBY_VERSION < '1.9.2'
         expect(out.first).to match(/^\s+m3\(arg1, arg2\)\s+Hello\s\(unbound\)$/)
       else
@@ -314,7 +314,7 @@ if RUBY_VERSION >= '1.9.2'
       class Hello
         def m1; end
       end
-      out = Hello.new.methods.ai(:plain => true).split("\n").grep(/m1/)
+      out = Hello.new.methods.ai(plain: true).split("\n").grep(/m1/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\)\s+Hello$/)
     end
 
@@ -322,7 +322,7 @@ if RUBY_VERSION >= '1.9.2'
       class Hello
         def m1(a, b, c); end
       end
-      out = Hello.new.methods.ai(:plain => true).split("\n").grep(/m1/)
+      out = Hello.new.methods.ai(plain: true).split("\n").grep(/m1/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(a, b, c\)\s+Hello$/)
     end
 
@@ -330,7 +330,7 @@ if RUBY_VERSION >= '1.9.2'
       class Hello
         def m1(a, b = 1, c = 2); end # m1(a, *b, *c)
       end
-      out = Hello.new.methods.ai(:plain => true).split("\n").grep(/m1/)
+      out = Hello.new.methods.ai(plain: true).split("\n").grep(/m1/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(a, \*b, \*c\)\s+Hello$/)
     end
 
@@ -338,7 +338,7 @@ if RUBY_VERSION >= '1.9.2'
       class Hello
         def m1(*a); end # m1(*a)
       end
-      out = Hello.new.methods.ai(:plain => true).split("\n").grep(/m1/)
+      out = Hello.new.methods.ai(plain: true).split("\n").grep(/m1/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(\*a\)\s+Hello$/)
     end
 
@@ -346,7 +346,7 @@ if RUBY_VERSION >= '1.9.2'
       class Hello
         def m1(a, b = nil, &blk); end # m1(a, *b, &blk)
       end
-      out = Hello.new.methods.ai(:plain => true).split("\n").grep(/m1/)
+      out = Hello.new.methods.ai(plain: true).split("\n").grep(/m1/)
       expect(out.first).to match(/^\s+\[\s*\d+\]\s+m1\(a, \*b, &blk\)\s+Hello$/)
     end
   end
@@ -363,7 +363,7 @@ RSpec.describe 'Methods arrays' do
     class Hello
       def self.m1; end
     end
-    out = (Hello.methods - Class.methods).ai(:plain => true)
+    out = (Hello.methods - Class.methods).ai(plain: true)
     expect(out).to eq("[\n    [0] m1() Hello\n]")
   end
 
@@ -376,7 +376,7 @@ RSpec.describe 'Methods arrays' do
     class World
       def self.m1; end
     end
-    out = (Hello.methods & World.methods - Class.methods).ai(:plain => true)
+    out = (Hello.methods & World.methods - Class.methods).ai(plain: true)
     expect(out).to eq("[\n    [0] m1() Hello\n]")
   end
 
@@ -387,9 +387,9 @@ RSpec.describe 'Methods arrays' do
       def self.m2; end
       def self.m3; end
     end
-    out = Hello.methods.grep(/^m1$/).ai(:plain => true)
+    out = Hello.methods.grep(/^m1$/).ai(plain: true)
     expect(out).to eq("[\n    [0] m1() Hello\n]")
-    out = Hello.methods.grep(/^m\d$/).ai(:plain => true)
+    out = Hello.methods.grep(/^m\d$/).ai(plain: true)
     expect(out).to eq("[\n    [0] m1() Hello\n    [1] m2() Hello\n    [2] m3() Hello\n]")
   end
 
@@ -412,7 +412,7 @@ RSpec.describe 'Methods arrays' do
       def self.one; end
     end
 
-    out = Hello.methods.grep(/^m(\d)$/) { %w(none one)[$1.to_i] }.ai(:plain => true)
+    out = Hello.methods.grep(/^m(\d)$/) { %w(none one)[$1.to_i] }.ai(plain: true)
     expect(out).to eq("[\n    [0] none() Hello\n    [1]  one() Hello\n]")
   end
 
@@ -437,11 +437,11 @@ RSpec.describe 'Methods arrays' do
 
   it 'appending garbage to methods array should not raise error' do
     arr = 42.methods << [ :wtf ]
-    expect { arr.ai(:plain => true) }.not_to raise_error
+    expect { arr.ai(plain: true) }.not_to raise_error
     if RUBY_VERSION < '1.9.2'
-      expect(arr.ai(:plain => true)).to match(/\s+wtf\(\?\)\s+\?/)      # [ :wtf ].to_s => "wtf"
+      expect(arr.ai(plain: true)).to match(/\s+wtf\(\?\)\s+\?/)      # [ :wtf ].to_s => "wtf"
     else
-      expect(arr.ai(:plain => true)).to match(/\s+\[:wtf\]\(\?\)\s+\?/) # [ :wtf ].to_s => [:wtf]
+      expect(arr.ai(plain: true)).to match(/\s+\[:wtf\]\(\?\)\s+\?/) # [ :wtf ].to_s => [:wtf]
     end
   end
 end

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'AwesomePrint' do
           nil
         end
       end
-      expect(weird.new.ai(:plain => true)).to eq('')
+      expect(weird.new.ai(plain: true)).to eq('')
     end
 
     it 'handle frozen object.inspect' do
@@ -18,14 +18,14 @@ RSpec.describe 'AwesomePrint' do
           'ice'.freeze
         end
       end
-      expect(weird.new.ai(:plain => false)).to eq('ice')
+      expect(weird.new.ai(plain: false)).to eq('ice')
     end
 
     # See https://github.com/awesome-print/awesome_print/issues/35
     it 'handle array grep when pattern contains / chapacter' do
       hash = { '1/x' => 1,  '2//x' => :"2" }
       grepped = hash.keys.sort.grep(/^(\d+)\//) { $1 }
-      expect(grepped.ai(:plain => true, :multiline => false)).to eq('[ "1", "2" ]')
+      expect(grepped.ai(plain: true, multiline: false)).to eq('[ "1", "2" ]')
     end
 
     # See https://github.com/awesome-print/awesome_print/issues/85
@@ -33,7 +33,7 @@ RSpec.describe 'AwesomePrint' do
       it "handle array grep when a method is defined in C and thus doesn't have a binding" do
         arr = (0..6).to_a
         grepped = arr.grep(1..4, &:succ)
-        expect(grepped.ai(:plain => true, :multiline => false)).to eq('[ 2, 3, 4, 5 ]')
+        expect(grepped.ai(plain: true, multiline: false)).to eq('[ 2, 3, 4, 5 ]')
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe 'AwesomePrint' do
     end
 
     it 'format ENV as hash' do
-      expect(ENV.ai(:plain => true)).to eq(ENV.to_hash.ai(:plain => true))
+      expect(ENV.ai(plain: true)).to eq(ENV.to_hash.ai(plain: true))
       expect(ENV.ai).to eq(ENV.to_hash.ai)
     end
 
@@ -78,17 +78,17 @@ RSpec.describe 'AwesomePrint' do
   describe 'HTML output' do
     it 'wraps ap output with plain <pre> tag' do
       markup = rand
-      expect(markup.ai(:html => true, :plain => true)).to eq("<pre>#{markup}</pre>")
+      expect(markup.ai(html: true, plain: true)).to eq("<pre>#{markup}</pre>")
     end
 
     it 'wraps ap output with <pre> tag with colorized <kbd>' do
       markup = rand
-      expect(markup.ai(:html => true)).to eq(%Q|<pre><kbd style="color:blue">#{markup}</kbd></pre>|)
+      expect(markup.ai(html: true)).to eq(%Q|<pre><kbd style="color:blue">#{markup}</kbd></pre>|)
     end
 
     it 'wraps multiline ap output with <pre> tag with colorized <kbd>' do
       markup = [ 1, :two, 'three' ]
-      expect(markup.ai(:html => true)).to eq <<-EOS.strip_heredoc.strip
+      expect(markup.ai(html: true)).to eq <<-EOS.strip_heredoc.strip
         <pre>[
             <kbd style="color:white">[0] </kbd><kbd style="color:blue">1</kbd>,
             <kbd style="color:white">[1] </kbd><kbd style="color:darkcyan">:two</kbd>,
@@ -99,7 +99,7 @@ RSpec.describe 'AwesomePrint' do
 
     it 'wraps hash ap output with only an outer <pre> tag' do
       markup = [ { 'hello' => 'world' } ]
-      expect(markup.ai(:html => true)).to eq <<-EOS.strip_heredoc.strip
+      expect(markup.ai(html: true)).to eq <<-EOS.strip_heredoc.strip
         <pre>[
             <kbd style="color:white">[0] </kbd>{
                 &quot;hello&quot;<kbd style="color:slategray"> =&gt; </kbd><kbd style="color:brown">&quot;world&quot;</kbd>
@@ -110,12 +110,12 @@ RSpec.describe 'AwesomePrint' do
 
     it 'encodes HTML entities (plain)' do
       markup = ' &<hello>'
-      expect(markup.ai(:html => true, :plain => true)).to eq('<pre>&quot; &amp;&lt;hello&gt;&quot;</pre>')
+      expect(markup.ai(html: true, plain: true)).to eq('<pre>&quot; &amp;&lt;hello&gt;&quot;</pre>')
     end
 
     it 'encodes HTML entities (color)' do
       markup = ' &<hello>'
-      expect(markup.ai(:html => true)).to eq('<pre><kbd style="color:brown">&quot; &amp;&lt;hello&gt;&quot;</kbd></pre>')
+      expect(markup.ai(html: true)).to eq('<pre><kbd style="color:brown">&quot; &amp;&lt;hello&gt;&quot;</kbd></pre>')
     end
   end
 
@@ -127,9 +127,9 @@ RSpec.describe 'AwesomePrint' do
 
     # See https://github.com/awesome-print/awesome_print/issues/98
     it 'should properly merge the defaults' do
-      AwesomePrint.defaults = { :indent => -2, :sort_keys => true }
+      AwesomePrint.defaults = { indent: -2, sort_keys: true }
       hash = { [0, 0, 255] => :yellow, :red => 'rgb(255, 0, 0)', 'magenta' => 'rgb(255, 0, 255)' }
-      out = hash.ai(:plain => true)
+      out = hash.ai(plain: true)
       expect(out).to eq <<-EOS.strip_heredoc.strip
         {
           [ 0, 0, 255 ] => :yellow,
@@ -160,7 +160,7 @@ RSpec.describe 'AwesomePrint' do
     end
 
     it 'shoud not raise ArgumentError when formatting HTML' do
-      out = 'hello'.ai(:color => { :string => :red }, :html => true)
+      out = 'hello'.ai(color: { string: :red }, html: true)
       if RUBY_VERSION >= '1.9'
         expect(out).to eq(%Q|<pre>[red]<kbd style="color:red">&quot;hello&quot;</kbd>[/red]</pre>|)
       else
@@ -169,17 +169,17 @@ RSpec.describe 'AwesomePrint' do
     end
 
     it 'shoud not raise ArgumentError when formatting HTML (shade color)' do
-      out = 'hello'.ai(:color => { :string => :redish }, :html => true)
+      out = 'hello'.ai(color: { string: :redish }, html: true)
       expect(out).to eq(%Q|<pre><kbd style="color:darkred">&quot;hello&quot;</kbd></pre>|)
     end
 
     it 'shoud not raise ArgumentError when formatting non-HTML' do
-      out = 'hello'.ai(:color => { :string => :red }, :html => false)
+      out = 'hello'.ai(color: { string: :red }, html: false)
       expect(out).to eq(%Q|[red]"hello"[/red]|)
     end
 
     it 'shoud not raise ArgumentError when formatting non-HTML (shade color)' do
-      out = 'hello'.ai(:color => { :string => :redish }, :html => false)
+      out = 'hello'.ai(color: { string: :redish }, html: false)
       expect(out).to eq(%Q|\e[0;31m"hello"\e[0m|)
     end
   end
@@ -221,13 +221,13 @@ RSpec.describe 'AwesomePrint' do
 
     it 'should return the actual object when *not* running under console' do
       expect(capture! { ap([ 1, 2, 3 ]) }).to eq([ 1, 2, 3 ])
-      expect(capture! { ap({ :a => 1 }) }).to eq({ :a => 1 })
+      expect(capture! { ap({ a: 1 }) }).to eq({ a: 1 })
     end
 
     it 'should return nil when running under console' do
       class IRB; end
       expect(capture! { ap([ 1, 2, 3 ]) }).to eq(nil)
-      expect(capture! { ap({ :a => 1 }) }).to eq(nil)
+      expect(capture! { ap({ a: 1 }) }).to eq(nil)
       Object.instance_eval{ remove_const :IRB }
     end
 

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Objects' do
       end
 
       hello = Hello.new
-      out = hello.ai(:plain => true, :raw => true)
+      out = hello.ai(plain: true, raw: true)
       str = <<-EOS.strip
 #<Hello:placeholder_id
     attr_accessor :dabra = 3,
@@ -27,7 +27,7 @@ RSpec.describe 'Objects' do
 >
 EOS
       expect(out).to be_similar_to(str)
-      expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
 
     it 'instance variables' do
@@ -38,7 +38,7 @@ EOS
       end
 
       hello = Hello.new
-      out = hello.ai(:plain => true, :raw => true)
+      out = hello.ai(plain: true, raw: true)
       str = <<-EOS.strip
 #<Hello:placeholder_id
     @abra = 1,
@@ -47,7 +47,7 @@ EOS
 >
 EOS
       expect(out).to be_similar_to(str)
-      expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
 
     it 'attributes and instance variables' do
@@ -63,7 +63,7 @@ EOS
       end
 
       hello = Hello.new
-      out = hello.ai(:plain => true, :raw => true)
+      out = hello.ai(plain: true, raw: true)
       str = <<-EOS.strip
 #<Hello:placeholder_id
     @doo = 1,
@@ -75,7 +75,7 @@ EOS
 >
 EOS
       expect(out).to be_similar_to(str)
-      expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
 
     it 'without the plain options print the colorized values' do
@@ -90,7 +90,7 @@ EOS
       end
 
       hello = Hello.new
-      out = hello.ai(:raw => true)
+      out = hello.ai(raw: true)
       str = <<-EOS.strip
 #<Hello:placeholder_id
     \e[0;36m@dabra\e[0m\e[0;37m = \e[0m\e[1;34m3\e[0m,
@@ -99,7 +99,7 @@ EOS
 >
 EOS
       expect(out).to be_similar_to(str)
-      expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
 
     it 'with multine as false show inline values' do
@@ -114,12 +114,12 @@ EOS
       end
 
       hello = Hello.new
-      out = hello.ai(:multiline => false, :plain => true, :raw => true)
+      out = hello.ai(multiline: false, plain: true, raw: true)
       str = <<-EOS.strip
 #<Hello:placeholder_id @dabra = 3, attr_reader :abra = 1, attr_writer :ca = 2>
 EOS
       expect(out).to be_similar_to(str)
-      expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
   end
 end


### PR DESCRIPTION
Use the ruby 1.9 hash syntax everywhere appropriate. This is to fix style
inconsistencies in the code base. This is also so that Hound can be used
without it bugging people every time they touch an older piece of code
but forget to update the syntax.

https://github.com/awesome-print/awesome_print/issues/279