### PR TITLE
Fix for `#to_hash` inspection logic.

### DIFF
--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -107,7 +107,7 @@ module AwesomePrint
     # Utility methods.
     #------------------------------------------------------------------------------
     def convert_to_hash(object)
-      if !object.respond_to?(:to_hash)
+      if !object.public_methods.include?(:to_hash)
         return nil
       end
 

--- a/spec/formats_spec.rb
+++ b/spec/formats_spec.rb
@@ -774,6 +774,28 @@ EOS
         my = My.new
         expect { my.ai(plain: true) }.not_to raise_error
       end
+
+      it "that responds to #to_hash but doesn't define it" do
+        class My
+          def method_missing(method_name, *args)
+            if method_name == :to_hash
+              {}
+            else
+              super
+            end
+          end
+          def respond_to?(*args)
+            if method_name == :to_hash
+              true
+            else
+              super
+            end
+          end
+        end
+
+        my = My.new
+        expect { my.ai(plain: true) }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Objects that respond to `#to_hash`, but do not define it, i.e. respond via method missing, cause for an unhelpful error to be raised.

Fixes this issue by replacing #respond_to? with checking the object's public methods.

See #275
Fixes #275