### PR TITLE
Sequel: avoid shadowing outer variable

### DIFF
--- a/lib/awesome_print/ext/sequel.rb
+++ b/lib/awesome_print/ext/sequel.rb
@@ -45,8 +45,8 @@ module AwesomePrint
     # Format Sequel Model class.
     #------------------------------------------------------------------------------
     def awesome_sequel_model_class(object)
-      data = object.db_schema.inject({}) { |h, (name, data)| h.merge(name => data[:db_type]) }
-      "class #{object} < #{object.superclass} " << awesome_hash(data)
+      result = object.db_schema.inject({}) { |h, (name, data)| h.merge(name => data[:db_type]) }
+      "class #{object} < #{object.superclass} " << awesome_hash(result)
     end
   end
 


### PR DESCRIPTION
This trivial style change avoids a Ruby warning:

```
/Users/olle/.rvm/gems/ruby-2.3.1/gems/awesome_print-1.7.0/
   lib/awesome_print/ext/sequel.rb:50: warning: shadowing outer local variable - data
```