### PR TITLE
removed Fixnum reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master (unreleased)
   - ActiveRecord: #joins now show the columns #select'ed [@adrianomitre] - [#211]
   - Handles NoMethodError for IRB implicit `ai` [@jtnegrotto] - [#212]
+  - Replaced Fixnum reference with Integer 
 
 ## 1.7.0
   - Refactoring by extracting formatters into their own classes [@waldyr] - [#237]

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -28,7 +28,7 @@ module AwesomePrint
       # ]
       #------------------------------------------------------------------------------
       def should_be_limited?
-        options[:limit] or (options[:limit].is_a?(Fixnum) and options[:limit] > 0)
+        options[:limit] or (options[:limit].is_a?(Integer) and options[:limit] > 0)
       end
 
       def get_limit_size


### PR DESCRIPTION
Since the Ruby-2.4.0 release, Fixnum and Bignum are combined into Integer class. This fix is to remove all Fixnum reference.