### PR TITLE
sort_vars option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ multiline:     true,   # Display in multiple lines.
 plain:         false,  # Use colors.
 raw:           false,  # Do not recursively format instance variables.
 sort_keys:     false,  # Do not sort hash keys.
+sort_vars:     true,   # Sort instance variables.
 limit:         false,  # Limit arrays & hashes. Accepts bool or int.
 ruby19_syntax: false,  # Use Ruby 1.9 hash syntax in output.
 color: {

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -28,7 +28,7 @@ module AwesomePrint
           end
         end
 
-        data = vars.sort.map do |declaration, var|
+        data = (options[:sort_vars] ? vars.sort : vars).map do |declaration, var|
           key = left_aligned do
             align(declaration, declaration.size)
           end

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -20,6 +20,7 @@ module AwesomePrint
         plain:         false,  # Use colors.
         raw:           false,  # Do not recursively format instance variables.
         sort_keys:     false,  # Do not sort hash keys.
+        sort_vars:     true,   # Sort instance variables.
         limit:         false,  # Limit arrays & hashes. Accepts bool or int.
         ruby19_syntax: false,  # Use Ruby 1.9 hash syntax in output.
         color: {

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -131,5 +131,41 @@ EOS
       expect(out).to be_similar_to(str)
       expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
+
+    it 'without the sort_vars option does not sort instance variables' do
+      class Hello
+        attr_reader   :abra
+        attr_writer   :ca
+        attr_accessor :dabra
+
+        def initialize
+          @abra = 1
+          @ca = 2
+          @dabra = 3
+          @scooby = 3
+          @dooby = 2
+          @doo = 1
+        end
+
+        def instance_variables
+          [:@scooby, :@dooby, :@doo, :@abra, :@ca, :@dabra]
+        end
+      end
+
+      hello = Hello.new
+      out = hello.ai(plain: true, raw: true, sort_vars: false)
+      str = <<-EOS.strip
+#<Hello:placeholder_id
+    @scooby = 3,
+    @dooby = 2,
+    @doo = 1,
+    attr_reader :abra = 1,
+    attr_writer :ca = 2,
+    attr_accessor :dabra = 3
+>
+EOS
+      expect(out).to be_similar_to(str)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
+    end
   end
 end


### PR DESCRIPTION
Hi!

First off, great lib! Thanks!
I was missing this feature, so here is a PR.

Motivation: To unclutter/customize the output of `pp` and/or `Object.inspect` I override `instance_variables` to return only the instance variables I care about, in the order I care about them. For example, if one of the instance variables is a somewhat large Hash, you might want to print that last, as to improve readability of all other vars. 

`pp` was easily forced to not sort the array by monkeypatching the `sort` method for the specific array with instance variables (or, their keys). But AwesomePrint maps the vars to a new array and sorts them later. 
This PR adds a `sort_vars` option (default `true`, nothing breaks) to disable this sorting.

Let me know what you think. If anything can be approved if you like the feature, etc.

Cheers!