### PR TITLE
options classname and object_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ raw:           false,  # Do not recursively format instance variables.
 sort_keys:     false,  # Do not sort hash keys.
 limit:         false,  # Limit arrays & hashes. Accepts bool or int.
 ruby19_syntax: false,  # Use Ruby 1.9 hash syntax in output.
+classname:     :class, # Methods used to get Instance class name.
+object_id:     true,   # Show object id.
 color: {
   args:       :pale,
   array:      :white,

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -60,7 +60,7 @@ module AwesomePrint
       end
 
       def awesome_instance
-        str = object.send(options[:classname])
+        str = object.send(options[:classname]).to_s
         str << ":0x%08x" % (object.__id__ * 2) if options[:object_id]
         str
       end

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -60,7 +60,9 @@ module AwesomePrint
       end
 
       def awesome_instance
-        "#{object.class}:0x%08x" % (object.__id__ * 2)
+        str = object.send(options[:classname])
+        str << ":0x%08x" % (object.__id__ * 2) if options[:object_id]
+        str
       end
 
       def left_aligned

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -22,6 +22,8 @@ module AwesomePrint
         sort_keys:     false,  # Do not sort hash keys.
         limit:         false,  # Limit arrays & hashes. Accepts bool or int.
         ruby19_syntax: false,  # Use Ruby 1.9 hash syntax in output.
+        classname:     :class, # Method used to get Instance class name.
+        object_id:     true,   # Show object_id.
         color: {
           args:       :pale,
           array:      :white,

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -131,5 +131,55 @@ EOS
       expect(out).to be_similar_to(str)
       expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
     end
+
+    it 'object_id' do
+      class Hello
+        def initialize
+          @abra = 1
+          @ca = 2
+          @dabra = 3
+        end
+      end
+
+      hello = Hello.new
+      out = hello.ai(plain: true, raw: true, object_id: false)
+      str = <<-EOS.strip
+#<Hello
+    @abra = 1,
+    @ca = 2,
+    @dabra = 3
+>
+EOS
+      expect(out).to be_similar_to(str)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
+    end
+
+    it 'classname' do
+      class Hello
+        def initialize
+          @abra = 1
+          @ca = 2
+          @dabra = 3
+        end
+
+        def to_s
+          "CustomizedHello"
+        end
+      end
+
+      hello = Hello.new
+      out = hello.ai(plain: true, raw: true, classname: :to_s)
+      str = <<-EOS.strip
+#<CustomizedHello:placeholder_id
+    @abra = 1,
+    @ca = 2,
+    @dabra = 3
+>
+EOS
+      expect(out).to be_similar_to(str)
+      expect(hello.ai(plain: true, raw: false)).to eq(hello.inspect)
+    end
+
+
   end
 end


### PR DESCRIPTION
Adds options to customize object classname and object_id output.

What do you think about this?

I don't think this is useful for many people, and it's probably better to introduce a way to add custom formatters (there isn't any at the moment, right?)

If it does seem useful, I think the new non-boolean/int option `classname` is probably a bad idea. A simple `use_to_s` switch would probably do, no?

For me personally, this combined with `sort_vars` options gives me great control over the output. Let me know what you think.

Cheers.
