### PR TITLE
Allow any object to override awesome print via #ai

### DIFF
--- a/lib/awesome_print/ext/active_record.rb
+++ b/lib/awesome_print/ext/active_record.rb
@@ -14,8 +14,7 @@ module AwesomePrint
     # Add ActiveRecord class names to the dispatcher pipeline.
     #------------------------------------------------------------------------------
     def cast_with_active_record(object, type)
-      cast = cast_without_active_record(object, type)
-      return cast if !defined?(::ActiveRecord::Base)
+      return cast_without_active_record(object, type) unless defined?(::ActiveRecord::Base)
 
       if object.is_a?(::ActiveRecord::Base)
         cast = :active_record_instance

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -31,7 +31,7 @@ module AwesomePrint
         if options[:multiline]
           multiline_array
         else
-          '[ ' << array.map { |item| inspector.awesome(item) }.join(', ') << ' ]'
+          '[ ' << array.map { |item| item) }.join(', '.ai(@options) << ' ]'
         end
       end
 
@@ -48,7 +48,7 @@ module AwesomePrint
       def generate_printable_array
         array.map.with_index do |item, index|
           array_prefix(index, width(array)).tap do |temp|
-            indented { temp << inspector.awesome(item) }
+            indented { temp << item.ai(@options) }
           end
         end
       end

--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -73,7 +73,7 @@ module AwesomePrint
 
         keys.map! do |key|
           plain_single_line do
-            [inspector.awesome(key), hash[key]]
+            [key.ai(@options), hash[key]]
           end
         end
       end
@@ -84,11 +84,11 @@ module AwesomePrint
 
       def ruby19_syntax(key, value, width)
         key[0] = ''
-        align(key, width - 1) << colorize(': ', :hash) << inspector.awesome(value)
+        align(key, width - 1) << colorize(': ', :hash) << value.ai(@options)
       end
 
       def pre_ruby19_syntax(key, value, width)
-        align(key, width) << colorize(' => ', :hash) << inspector.awesome(value)
+        align(key, width) << colorize(' => ', :hash) << value.ai(@options)
       end
 
       def plain_single_line

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -42,7 +42,7 @@ module AwesomePrint
           end
 
           indented do
-            key << colorize(' = ', :hash) + inspector.awesome(object.instance_variable_get(var))
+            key << colorize(' = ', :hash) + object.instance_variable_get(var).ai(@options)
           end
         end
 

--- a/lib/awesome_print/formatters/struct_formatter.rb
+++ b/lib/awesome_print/formatters/struct_formatter.rb
@@ -42,7 +42,7 @@ module AwesomePrint
           end
 
           indented do
-            key << colorize(' = ', :hash) + inspector.awesome(struct.send(var))
+            key << colorize(' = ', :hash) + struct.send(var).ai(@options)
           end
         end
 

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -134,6 +134,7 @@ module AwesomePrint
     # keys.
     #---------------------------------------------------------------------------
     def merge_options!(options = {})
+      options = options.dup
       @options[:color].merge!(options.delete(:color) || {})
       @options.merge!(options)
     end


### PR DESCRIPTION
Bug fix: Duplicate options before mutating it

Changes:
- calls to `inspector.awesome(x)` are replaced with `x.ai(@options)`

I noticed that ai calls `inspector.awesome` so I figured we can change it `#ai` without breaking much. I know this way is less efficient but for debugging, it's not going to be a huge concern. 