### PR TITLE
Fix rails version to pass tests

### DIFF
--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 5.0.0.racecar1", "< 5.1"
+gem "rails", "~> 5.0.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
I'm trying to fix failing tests due to rails version mismatch.

## Overview

As of now, it installs not `5.0.x` but `5.1.0.rc2` with `gem "rails", ">= 5.0.0.racecar1", "< 5.1"`. So [`activerecord_5_0?` in the test](https://github.com/awesome-print/awesome_print/blob/5dc306cca751941df35c9858271a58f37bc36f5f/spec/ext/active_record_spec.rb#L129) returns `false` then some tests fail.