### PR TITLE
ArrayFormatter now returns arrays for has_many :through associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master (unreleased)
-  - new things!
+  - ArrayFormatter now returns arrays for has_many :through associations [@chadh13] - [#332]
 
 ## 1.8.0
   - stat("$HOME/.aprc") once [@kstephens] - [#304]

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -12,7 +12,7 @@ module AwesomePrint
       end
 
       def format
-        if array.empty?
+        if array.length.zero?
           '[]'
         elsif methods_array?
           methods_array


### PR DESCRIPTION
The array_formatter was always returning  an empty array when associated objects were called via a `has_many through:` relationship because they are loaded as a collection, and the collection is always considered empty.

resolves: https://github.com/awesome-print/awesome_print/issues/331