### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
   - new things!
+  - Improve performance [@paddor] - [#333]
 
 ## 1.8.0
   - stat("$HOME/.aprc") once [@kstephens] - [#304]

--- a/lib/awesome_print/colorize.rb
+++ b/lib/awesome_print/colorize.rb
@@ -6,18 +6,32 @@ module AwesomePrint
     # Pick the color and apply it to the given string as necessary.
     #------------------------------------------------------------------------------
     def colorize(str, type)
-      str = CGI.escapeHTML(str) if options[:html]
-      if options[:plain] || !options[:color][type] || !inspector.colorize?
-        str
+      # cache (this method can be called many times for just one call to #ai)
+      # NOTE: MUST NOT cache options[:plain]. (see HashFormatter)
+      @options_color = options[:color] unless defined? @options_color
+      @options_html  = options[:html]  unless defined? @options_html
+      color          = @options_color[type]
+
+      str = CGI.escapeHTML(str) if @options_html # WTF is this doing here
+
+      return str if options[:plain] || !color || !inspector.colorize?
+
+      # Common case: HTML is not wanted.
+      return str.send(color) unless @options_html
+
+      ###
+      # Special case: HTML is wanted.
+      #
+
       #
       # Check if the string color method is defined by awesome_print and accepts
       # html parameter or it has been overriden by some gem such as colorize.
       #
-      elsif str.method(options[:color][type]).arity == -1 # Accepts html parameter.
-        str.send(options[:color][type], options[:html])
+      if str.method(color).arity == -1 # Accepts html parameter.
+        # TODO: Redundant. Just always do HTML colorizing here, remove html param from color methods on String.
+        str.send(color, @options_html)
       else
-        str = %Q|<kbd style="color:#{options[:color][type]}">#{str}</kbd>| if options[:html]
-        str.send(options[:color][type])
+        %Q|<kbd style="color:#{color}">#{str}</kbd>|.send(color) # WTF? ANSI-colorize the HTML?
       end
     end
   end

--- a/lib/awesome_print/core_ext/class.rb
+++ b/lib/awesome_print/core_ext/class.rb
@@ -32,7 +32,7 @@ end
 
 
 class Array
-  def self.awesome_print_name
+  def self.awesome_print_type
     :array
   end
 end

--- a/lib/awesome_print/core_ext/class.rb
+++ b/lib/awesome_print/core_ext/class.rb
@@ -20,4 +20,48 @@ class Class #:nodoc:
       methods
     end
   end
+
+
+  # Turn class name into symbol, ex: Hello::World => :hello_world. Classes
+  # that inherit from Array, Hash, File, Dir, and Struct are treated as the
+  # base class.
+  def awesome_print_type
+    @awesome_print_type ||= to_s.gsub(/:+/, '_').downcase.to_sym
+  end
 end
+
+
+class Array
+  def self.awesome_print_name
+    :array
+  end
+end
+
+
+class Hash
+  def self.awesome_print_type
+    :hash
+  end
+end
+
+
+class File
+  def self.awesome_print_type
+    :file
+  end
+end
+
+
+class Dir
+  def self.awesome_print_type
+    :dir
+  end
+end
+
+
+class Struct
+  def self.awesome_print_type
+    :struct
+  end
+end
+

--- a/lib/awesome_print/core_ext/string.rb
+++ b/lib/awesome_print/core_ext/string.rb
@@ -16,12 +16,19 @@ class String
   #
   %w(gray red green yellow blue purple cyan white).zip(
   %w(black darkred darkgreen brown navy darkmagenta darkcyan slategray)).each_with_index do |(color, shade), i|
-    define_method color do |*html|
-      html[0] ? %Q|<kbd style="color:#{color}">#{self}</kbd>| : "\e[1;#{30 + i}m#{self}\e[0m"
+
+    term_bright_seq = "\e[1;#{30 + i}m%s\e[0m"
+    html_bright_seq = %Q|<kbd style="color:#{color}">%s</kbd>|
+
+    define_method color do |html = false,*|
+      (html ? html_bright_seq : term_bright_seq) % self
     end
 
-    define_method "#{color}ish" do |*html|
-      html[0] ? %Q|<kbd style="color:#{shade}">#{self}</kbd>| : "\e[0;#{30 + i}m#{self}\e[0m"
+    term_normal_seq = "\e[0;#{30 + i}m%s\e[0m"
+    html_normal_seq = %Q|<kbd style="color:#{shade}">%s</kbd>|
+
+    define_method "#{color}ish" do |html = false,*|
+      (html ? html_normal_seq : term_normal_seq) % self
     end
   end
 

--- a/lib/awesome_print/core_ext/string.rb
+++ b/lib/awesome_print/core_ext/string.rb
@@ -17,18 +17,24 @@ class String
   %w(gray red green yellow blue purple cyan white).zip(
   %w(black darkred darkgreen brown navy darkmagenta darkcyan slategray)).each_with_index do |(color, shade), i|
 
-    term_bright_seq = "\e[1;#{30 + i}m%s\e[0m"
-    html_bright_seq = %Q|<kbd style="color:#{color}">%s</kbd>|
+    term_bright_seq = "\e[1;#{30 + i}m%s\e[0m" # avoid calls to Integer#to_s
 
     define_method color do |html = false,*|
-      (html ? html_bright_seq : term_bright_seq) % self
+      if html
+        %Q|<kbd style="color:#{color}">#{self}</kbd>|
+      else
+        term_bright_seq % self
+      end
     end
 
-    term_normal_seq = "\e[0;#{30 + i}m%s\e[0m"
-    html_normal_seq = %Q|<kbd style="color:#{shade}">%s</kbd>|
+    term_normal_seq = "\e[0;#{30 + i}m%s\e[0m" # avoid calls to Integer#to_s
 
     define_method "#{color}ish" do |html = false,*|
-      (html ? html_normal_seq : term_normal_seq) % self
+      if html
+        %Q|<kbd style="color:#{shade}">#{self}</kbd>|
+      else
+        term_normal_seq % self
+      end
     end
   end
 

--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -117,7 +117,7 @@ module AwesomePrint
       end
 
       hash = object.to_hash
-      if !hash.respond_to?(:keys) || !hash.respond_to?('[]')
+      if !hash.respond_to?(:keys) || !hash.respond_to?(:[])
         return nil
       end
 

--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -4,6 +4,7 @@
 # See LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 require 'awesome_print/formatters'
+require 'set'
 
 module AwesomePrint
   class Formatter
@@ -11,7 +12,7 @@ module AwesomePrint
 
     attr_reader :inspector, :options
 
-    CORE = [:array, :bigdecimal, :class, :dir, :file, :hash, :method, :rational, :set, :struct, :unboundmethod]
+    CORE = Set.new [:array, :bigdecimal, :class, :dir, :file, :hash, :method, :rational, :set, :struct, :unboundmethod]
 
     def initialize(inspector)
       @inspector   = inspector
@@ -33,8 +34,8 @@ module AwesomePrint
     # Hook this when adding custom formatters. Check out lib/awesome_print/ext
     # directory for custom formatters that ship with awesome_print.
     #------------------------------------------------------------------------------
-    def cast(object, type)
-      CORE.grep(type)[0] || :self
+    def cast(_object, type)
+      CORE.include?(type) ? type : :self
     end
 
     private

--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -69,40 +69,49 @@ module AwesomePrint
     end
 
     def awesome_array(a)
-      Formatters::ArrayFormatter.new(a, @inspector).format
+      @array_formatter ||= Formatters::ArrayFormatter.new(:__placeholder,  @inspector)
+      @array_formatter.format_object(a)
     end
 
     def awesome_set(s)
-      Formatters::ArrayFormatter.new(s.to_a, @inspector).format
+      @array_formatter ||= Formatters::ArrayFormatter.new(:__placeholder, @inspector)
+      @array_formatter.format_object(s.to_a)
     end
 
     def awesome_hash(h)
-      Formatters::HashFormatter.new(h, @inspector).format
+      @hash_formatter ||= Formatters::HashFormatter.new(:__placeholder, @inspector)
+      @hash_formatter.format_object(h)
     end
 
     def awesome_object(o)
-      Formatters::ObjectFormatter.new(o, @inspector).format
+      @object_formatter ||= Formatters::ObjectFormatter.new(:__placeholder, @inspector)
+      @object_formatter.format_object(o)
     end
 
     def awesome_struct(s)
-      Formatters::StructFormatter.new(s, @inspector).format
+      @struct_formatter ||= Formatters::StructFormatter.new(:__placeholder, @inspector)
+      @struct_formatter.format_object(s)
     end
 
     def awesome_method(m)
-      Formatters::MethodFormatter.new(m, @inspector).format
+      @method_formatter ||= Formatters::MethodFormatter.new(:__placeholder, @inspector)
+      @method_formatter.format_object(m)
     end
     alias :awesome_unboundmethod :awesome_method
 
     def awesome_class(c)
-      Formatters::ClassFormatter.new(c, @inspector).format
+      @class_formatter ||= Formatters::ClassFormatter.new(:__placeholder, @inspector)
+      @class_formatter.format_object(c)
     end
 
     def awesome_file(f)
-      Formatters::FileFormatter.new(f, @inspector).format
+      @file_formatter ||= Formatters::FileFormatter.new(:__placeholder, @inspector)
+      @file_formatter.format_object(f)
     end
 
     def awesome_dir(d)
-      Formatters::DirFormatter.new(d, @inspector).format
+      @dir_formatter ||= Formatters::DirFormatter.new(:__placeholder, @inspector)
+      @dir_formatter.format_object(d)
     end
 
     # Utility methods.

--- a/lib/awesome_print/formatter.rb
+++ b/lib/awesome_print/formatter.rb
@@ -121,16 +121,14 @@ module AwesomePrint
         return nil
       end
 
-      if object.method(:to_hash).arity != 0
+      begin
+        obj = object.to_hash
+        return obj if obj.is_a? Hash
+      rescue ArgumentError
         return nil
       end
 
-      hash = object.to_hash
-      if !hash.respond_to?(:keys) || !hash.respond_to?(:[])
-        return nil
-      end
-
-      return hash
+      nil
     end
   end
 end

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -3,12 +3,9 @@ require_relative 'base_formatter'
 module AwesomePrint
   module Formatters
     class ArrayFormatter < BaseFormatter
-      attr_reader :array, :inspector, :options
 
-      def initialize(array, inspector)
-        @array = array
-        @inspector = inspector
-        @options = inspector.options
+      def array
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -33,21 +33,54 @@ module AwesomePrint
       end
 
       def multiline_array
-        data = unless should_be_limited?
-                 generate_printable_array
+        data = if should_be_limited?
+                 generate_limited_printable_array
                else
-                 limited(generate_printable_array, width(array))
+                 generate_printable_array
                end
 
         %Q([\n#{data.join(",\n")}\n#{outdent}])
       end
 
       def generate_printable_array
+        array_width = width(array) # cache
+
         array.map.with_index do |item, index|
-          array_prefix(index, width(array)).tap do |temp|
+          array_prefix(index, array_width).tap do |temp|
             indented { temp << inspector.awesome(item) }
           end
         end
+      end
+
+      # Avoids colorizing a possibly huge array and THEN only limitting it.
+      # This should be much faster.
+      def generate_limited_printable_array
+        limit = get_limit_size
+        return generate_printable_array if array.length <= limit
+
+        # cache
+        array_width = width(array)
+        inspector = inspector()
+
+        # Calculate how many elements to be displayed above and below the separator.
+        nhead = limit / 2
+        ntail = nhead - (limit - 1) % 2
+
+        head = array.first(nhead).map.with_index do |item, index|
+          array_prefix(index, array_width).tap do |temp|
+            indented { temp << inspector.awesome(item) }
+          end
+        end
+
+        separator = "#{indent}[#{nhead.to_s.rjust(array_width)}] .. [#{array.length - ntail - 1}]"
+
+        tail = array.last(ntail).map.with_index(array.length - ntail) do |item, index|
+          array_prefix(index, array_width).tap do |temp|
+            indented { temp << inspector.awesome(item) }
+          end
+        end
+
+        [ *head, separator, *tail ]
       end
 
       def array_prefix(iteration, width)

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -21,7 +21,7 @@ module AwesomePrint
       private
 
       def methods_array?
-        array.instance_variable_defined?('@__awesome_methods__')
+        array.instance_variable_defined?(:@__awesome_methods__)
       end
 
       def simple_array

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -19,8 +19,13 @@ module AwesomePrint
 
       # Set object and delegate to {#format}.
       def format_object(obj)
-        @object = obj
+        # NOTE: This makes use of the stack to allow reusing this formatter for
+        # sub objects in nested structures.
+
+        previous, @object = @object, obj # push
         format
+      ensure
+        @object = previous # pop
       end
 
 

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -5,6 +5,25 @@ module AwesomePrint
     class BaseFormatter
       include Colorize
 
+      attr_accessor :object
+
+      attr_reader :inspector
+
+      attr_reader :options
+
+      def initialize(object, inspector)
+        @object = object
+        @inspector = inspector
+        @options = inspector.options
+      end
+
+      # Set object and delegate to {#format}.
+      def format_object(obj)
+        @object = obj
+        format
+      end
+
+
       DEFAULT_LIMIT_SIZE = 7
 
       # To support limited output, for example:

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -113,22 +113,28 @@ module AwesomePrint
         inspector.increase_indentation(&blk)
       end
 
-      def indent
-        ' ' * indentation
+      # precompute common indentations
+      INDENT_CACHE = (0..100).map { |i| ' ' * i }.map(&:freeze).freeze
+
+      def indent(n = indentation)
+        INDENT_CACHE[n] or ' ' * n
       end
 
       def outdent
-        ' ' * (indentation - options[:indent].abs)
+        i = indentation - options[:indent].abs
+
+        INDENT_CACHE[i] or ' ' * i
       end
 
       def align(value, width)
         if options[:multiline]
-          if options[:indent] > 0
+          indent_option = options[:indent]
+          if indent_option > 0
             value.rjust(width)
-          elsif options[:indent] == 0
-            indent + value.ljust(width)
+          elsif indent_option == 0
+            "#{indent}#{value.ljust(width)}"
           else
-            indent[0, indentation + options[:indent]] + value.ljust(width)
+            "#{indent(indentation + indent_option)}#{value.ljust(width)}"
           end
         else
           value

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -109,8 +109,8 @@ module AwesomePrint
         inspector.current_indentation
       end
 
-      def indented
-        inspector.increase_indentation(&Proc.new)
+      def indented(&blk)
+        inspector.increase_indentation(&blk)
       end
 
       def indent

--- a/lib/awesome_print/formatters/class_formatter.rb
+++ b/lib/awesome_print/formatters/class_formatter.rb
@@ -4,12 +4,8 @@ module AwesomePrint
   module Formatters
     class ClassFormatter < BaseFormatter
 
-      attr_reader :klass, :inspector, :options
-
-      def initialize(klass, inspector)
-        @klass = klass
-        @inspector = inspector
-        @options = inspector.options
+      def klass
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/dir_formatter.rb
+++ b/lib/awesome_print/formatters/dir_formatter.rb
@@ -5,12 +5,8 @@ module AwesomePrint
   module Formatters
     class DirFormatter < BaseFormatter
 
-      attr_reader :dir, :inspector, :options
-
-      def initialize(dir, inspector)
-        @dir = dir
-        @inspector = inspector
-        @options = inspector.options
+      def dir
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/file_formatter.rb
+++ b/lib/awesome_print/formatters/file_formatter.rb
@@ -5,12 +5,8 @@ module AwesomePrint
   module Formatters
     class FileFormatter < BaseFormatter
 
-      attr_reader :file, :inspector, :options
-
-      def initialize(file, inspector)
-        @file = file
-        @inspector = inspector
-        @options = inspector.options
+      def file
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -65,7 +65,7 @@ module AwesomePrint
       def printable_keys
         keys = hash.keys
 
-        keys.sort! { |a, b| a.to_s <=> b.to_s } if options[:sort_keys]
+        keys = keys.sort_by { |k| k.to_s } if options[:sort_keys]
 
         keys.map! do |key|
           plain_single_line do

--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -3,12 +3,8 @@ require_relative 'base_formatter'
 module AwesomePrint
   module Formatters
     class HashFormatter < BaseFormatter
-      attr_reader :hash, :inspector, :options
-
-      def initialize(hash, inspector)
-        @hash = hash
-        @inspector = inspector
-        @options = inspector.options
+      def hash
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/method_formatter.rb
+++ b/lib/awesome_print/formatters/method_formatter.rb
@@ -4,12 +4,8 @@ module AwesomePrint
   module Formatters
     class MethodFormatter < BaseFormatter
 
-      attr_reader :method, :inspector, :options
-
-      def initialize(method, inspector)
-        @method = method
-        @inspector = inspector
-        @options = inspector.options
+      def method
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -4,13 +4,11 @@ module AwesomePrint
   module Formatters
     class ObjectFormatter < BaseFormatter
 
-      attr_reader :object, :variables, :inspector, :options
+      attr_reader :variables
 
       def initialize(object, inspector)
-        @object = object
+        super
         @variables = object.instance_variables
-        @inspector = inspector
-        @options = inspector.options
       end
 
       def format

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -29,8 +29,9 @@ module AwesomePrint
           end
 
           unless options[:plain]
-            if key =~ /(@\w+)/
-              key.sub!($1, colorize($1, :variable))
+            if index = (key =~ /(@\w+)/)
+              # NOTE: Reusing index to avoid calling String#sub! and find the pattern again.
+              key[index, $1.length] = colorize($1, :variable)
             else
               key.sub!(/(attr_\w+)\s(\:\w+)/, "#{colorize('\\1', :keyword)} #{colorize('\\2', :method)}")
             end

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -4,11 +4,8 @@ module AwesomePrint
   module Formatters
     class ObjectFormatter < BaseFormatter
 
-      attr_reader :variables
-
-      def initialize(object, inspector)
-        super
-        @variables = object.instance_variables
+      def variables
+        @object.instance_variables
       end
 
       def format

--- a/lib/awesome_print/formatters/simple_formatter.rb
+++ b/lib/awesome_print/formatters/simple_formatter.rb
@@ -4,13 +4,16 @@ module AwesomePrint
   module Formatters
     class SimpleFormatter < BaseFormatter
 
-      attr_reader :string, :type, :inspector, :options
+      attr_accessor :type
+
+      def string
+        @object
+      end
+
 
       def initialize(string, type, inspector)
-        @string = string
+        super(string, inspector)
         @type = type
-        @inspector = inspector
-        @options = inspector.options
       end
 
       def format

--- a/lib/awesome_print/formatters/struct_formatter.rb
+++ b/lib/awesome_print/formatters/struct_formatter.rb
@@ -4,13 +4,15 @@ module AwesomePrint
   module Formatters
     class StructFormatter < BaseFormatter
 
-      attr_reader :struct, :variables, :inspector, :options
+      attr_reader :variables
 
       def initialize(struct, inspector)
-        @struct = struct
+        super
         @variables = struct.members
-        @inspector = inspector
-        @options = inspector.options
+      end
+
+      def struct
+        @object
       end
 
       def format

--- a/lib/awesome_print/formatters/struct_formatter.rb
+++ b/lib/awesome_print/formatters/struct_formatter.rb
@@ -4,15 +4,12 @@ module AwesomePrint
   module Formatters
     class StructFormatter < BaseFormatter
 
-      attr_reader :variables
-
-      def initialize(struct, inspector)
-        super
-        @variables = struct.members
-      end
-
       def struct
         @object
+      end
+
+      def variables
+        @object.members
       end
 
       def format

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -107,7 +107,7 @@ module AwesomePrint
     #   => { :a => 1, :b => {...} }
     #---------------------------------------------------------------------------
     def nested(object)
-      case printable(object)
+      case object.class.awesome_print_type
       when :array  then @formatter.colorize('[...]', :array)
       when :hash   then @formatter.colorize('{...}', :hash)
       when :struct then @formatter.colorize('{...}', :struct)
@@ -117,22 +117,7 @@ module AwesomePrint
 
     #---------------------------------------------------------------------------
     def unnested(object)
-      @formatter.format(object, printable(object))
-    end
-
-    # Turn class name into symbol, ex: Hello::World => :hello_world. Classes
-    # that inherit from Array, Hash, File, Dir, and Struct are treated as the
-    # base class.
-    #---------------------------------------------------------------------------
-    def printable(object)
-      case object
-      when Array  then :array
-      when Hash   then :hash
-      when File   then :file
-      when Dir    then :dir
-      when Struct then :struct
-      else object.class.to_s.gsub(/:+/, '_').downcase.to_sym
-      end
+      @formatter.format(object, object.class.awesome_print_type)
     end
 
     # Update @options by first merging the :color hash and then the remaining

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -60,8 +60,8 @@ module AwesomePrint
       indentator.indentation
     end
 
-    def increase_indentation
-      indentator.indent(&Proc.new)
+    def increase_indentation(&blk)
+      indentator.indent(&blk)
     end
 
     # Dispatcher that detects data nesting and invokes object-aware formatter.

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -67,11 +67,13 @@ module AwesomePrint
     # Dispatcher that detects data nesting and invokes object-aware formatter.
     #---------------------------------------------------------------------------
     def awesome(object)
-      if Thread.current[AP].include?(object.object_id)
+      oid = object.object_id # cache
+
+      if Thread.current[AP].include?(oid)
         nested(object)
       else
         begin
-          Thread.current[AP] << object.object_id
+          Thread.current[AP] << oid
           unnested(object)
         ensure
           Thread.current[AP].pop

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -84,13 +84,17 @@ module AwesomePrint
     def colorize?
       AwesomePrint.force_colors ||= false
       AwesomePrint.force_colors || (
-        STDOUT.tty? && (
-          (
-            ENV['TERM'] &&
-            ENV['TERM'] != 'dumb'
-          ) ||
-          ENV['ANSICON']
-        )
+        if defined? @colorize_STDOUT
+          @colorize_STDOUT
+        else
+          @colorize_STDOUT = STDOUT.tty? && (
+            (
+              ENV['TERM'] &&
+              ENV['TERM'] != 'dumb'
+            ) ||
+            ENV['ANSICON']
+          )
+        end
       )
     end
 


### PR DESCRIPTION
To make AwesomePrint usable in a high-traffic, colorized log, I made a few optimizations.

Here the first few lines of RubyProf's profiling before (left) and after (right):

```
Measure Mode: wall_time												Measure Mode: wall_time
Thread ID: 16869000											     |	Thread ID: 8005260
Fiber ID: 119289720											     |	Fiber ID: 85516140
Total: 168.812981											     |	Total: 166.237770
Sort by: self_time												Sort by: self_time

 %self      total      self      wait     child     calls  name							 %self      total      self      wait     child     calls  name
  9.86     34.460    16.649     0.000    17.811  8339561   AwesomePrint::Colorize#colorize		     |	 83.78    166.237   139.275     0.000    26.962        1   <Module::EventMachine>#run_machine
  6.25    168.812    10.549     0.000   158.263        1   <Module::EventMachine>#run_machine		     |	  1.42      4.825     2.368     0.000     2.458   875843   AwesomePrint::Colorize#colorize
  2.82      4.769     4.769     0.000     0.000 38670951   Symbol#===					     |	  1.34      2.338     2.233     0.000     0.105     6249   <Module::Marshal>#load
  2.67      4.510     4.510     0.000     0.000  1397819   String#sub!					     |	  0.89      1.473     1.473     0.000     0.000   803770   String#%
  2.40      5.402     4.052     0.000     1.349  3515541   AwesomePrint::Inspector#printable		     |	  0.44      0.729     0.728     0.000     0.000   141140   String#sub!
  2.13      3.603     3.603     0.000     0.000  7434729   Kernel#method				     |	  0.38      1.046     0.628     0.000     0.418   245337   AwesomePrint::Formatters::BaseFormatter#align
  1.96      3.316     3.316     0.000     0.000  7434722   AwesomePrint::Inspector#colorize?		     |	  0.29      0.480     0.480     0.000     0.000   771620   AwesomePrint::Inspector#colorize?
  1.78     13.034     2.998     0.000    10.036  3515541   Enumerable#grep				     |	  0.28      0.463     0.463     0.000     0.000   610388   Symbol#to_s
```

Here's a longer [profile diff](https://gist.github.com/paddor/a887aa95eaad81126992f45115abb803).