### PR TITLE
Retain custom color defaults

### DIFF
--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -137,8 +137,8 @@ module AwesomePrint
     # keys.
     #---------------------------------------------------------------------------
     def merge_options!(options = {})
-      @options[:color].merge!(options.delete(:color) || {})
-      @options.merge!(options)
+      @options[:color].merge!(options[:color] || {})
+      @options.merge!(options.reject { |key, _value| key == :color })
     end
 
     # This method needs to be mocked during testing so that it always loads

--- a/spec/custom_default_colors_spec.rb
+++ b/spec/custom_default_colors_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe 'AwesomePrint' do
+  describe 'custom default colors' do
+    around do |example|
+      original_defaults = AwesomePrint.defaults
+      example.run
+      AwesomePrint.defaults = original_defaults
+    end
+
+    it 'retains programmatically set defaults' do
+      array = [1, 2, 3]
+      red_array_indexes = "[\n    \e[1\;31m[0] \e[0m\e[1\;34m1\e[0m,\n    \e[1\;31m[1] \e[0m\e[1\;34m2\e[0m,\n    \e[1\;31m[2] \e[0m\e[1\;34m3\e[0m\n]"
+      AwesomePrint.defaults = {color: {array: :red}}
+      array.ai
+      expect(array.ai).to eq(red_array_indexes)
+    end
+  end
+end


### PR DESCRIPTION
When using custom color defaults by setting `AwesomePrint.defaults` from anywhere else than `~/.aprc` then the custom coloring was gone after the first object had been inspected.
This was due to the permanent removal of the `:color` key from the given options.
This PR ensures that the given options are not modified.

Fixes #209