### PR TITLE
Ignore AR accessors raising errors

### DIFF
--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',  '>= 3.0.0'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'fakefs', '>= 0.2.1'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3', '< 1.4'
   s.add_development_dependency 'nokogiri', '>= 1.6.5'
   # s.add_development_dependency 'simplecov'
   # s.add_development_dependency 'codeclimate-test-reporter'

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -10,6 +10,29 @@ RSpec.describe 'AwesomePrint/ActiveRecord', skip: -> { !ExtVerifier.has_rails? }
       @ap = AwesomePrint::Inspector.new(plain: true, sort_keys: true)
     end
 
+    it 'ignores accessors raising errors' do
+      def @diana.name
+        raise "Oh no! I'm a deprecated method, you can't access me"
+      end
+
+      out = @ap.awesome(@diana)
+      str = <<-EOS.strip
+#<User:placeholder_id> {
+         :admin => false,
+    :created_at => ?,
+            :id => nil,
+          :name => nil,
+          :rank => 1
+}
+      EOS
+      if RUBY_VERSION < '1.9'
+        str.sub!('?', 'Sat Oct 10 12:30:00 UTC 1992')
+      else
+        str.sub!('?', '1992-10-10 12:30:00 UTC')
+      end
+      expect(out).to be_similar_to(str)
+    end
+
     it 'display single record' do
       out = @ap.awesome(@diana)
       str = <<-EOS.strip


### PR DESCRIPTION
Solidus deprecated some AR attributes by raising errors, but without removing the columns in the database:

https://github.com/solidusio/solidus/blob/v1.4.2/core/app/models/spree/promotion.rb#L57-L63

With that, if we try to load a promotion `Spree::Promotion.first` with awesome-print we get:

```sh
Spree::Promotion.first
  Spree::Promotion Load (0.6ms)  SELECT "spree_promotions".* FROM "spree_promotions"
(pry) output error: #<RuntimeError: Attempted to call code on a Spree::Promotion. Promotions are now tied to multiple code records>
```

Making `Spree::Promotion` inaccessible via console when using awesome_print.

This pull request ignores errors when errors when loading attributes.