### PR TITLE
Change &Proc.new to &block for ruby 2.7 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Adds support for ActiveModel::Errors [@dshinzie] - [#301]
   - removes use of `strip_heredoc` from specs as it's a rails dep [@kstephens] - [#303]
   - ArrayFormatter now returns arrays for has_many :through associations [@chadh13] - [#332]
+  - Change `&Proc.new` to `&block` for ruby 2.7 warning [@QWYNG]
 
 ## 1.8.0
   - stat("$HOME/.aprc") once [@kstephens] - [#304]

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -110,7 +110,7 @@ module AwesomePrint
       end
 
       def indented
-        inspector.increase_indentation(&Proc.new)
+        inspector.increase_indentation(&block)
       end
 
       def indent

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -109,7 +109,7 @@ module AwesomePrint
         inspector.current_indentation
       end
 
-      def indented
+      def indented(&block)
         inspector.increase_indentation(&block)
       end
 

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -63,7 +63,7 @@ module AwesomePrint
     end
 
     def increase_indentation
-      indentator.indent(&Proc.new)
+      indentator.indent(&block)
     end
 
     # Dispatcher that detects data nesting and invokes object-aware formatter.

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -62,7 +62,7 @@ module AwesomePrint
       indentator.indentation
     end
 
-    def increase_indentation
+    def increase_indentation(&block)
       indentator.indent(&block)
     end
 


### PR DESCRIPTION
Hi! thank you for a great gem! 

ruby trank is merged this warning
https://github.com/ruby/ruby/commit/d3da5fbd30e174c5737ec09c6896db7e81691714

I think that Using `&block` is better than `&Proc.new` for Capturing the given block

Hope it makes sense