### PR TITLE
Allow for optional, non-html output in action_view

### DIFF
--- a/lib/awesome_print/ext/action_view.rb
+++ b/lib/awesome_print/ext/action_view.rb
@@ -8,7 +8,7 @@ module AwesomePrint
     # Use HTML colors and add default "debug_dump" class to the resulting HTML.
     def ap_debug(object, options = {})
       object.ai(
-        options.merge(html: true)
+        {html: true}.merge(options)
       ).sub(
         /^<pre([\s>])/,
         '<pre class="debug_dump"\\1'


### PR DESCRIPTION
When html: false is explicitly set, that should not be overridden by the ext/action_view, i.e. defaults must not be forced.

Usage scenario:
Rails+cucumber+byebug+awesome_print. I type in my view (index.slim) "- byebug". Then I run cucumber test. Then the test stops at that byebug line, providing me with a byebug console in that context from terminal. Then I type "ap product" and I get the default behaviour - a lot of html output in console - not needed. Then I type "ap product, html: false" and to my surprise I get the same output. That's because my html: false was overridden by awesome print ext/action_view.