### PR TITLE
Fix build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ matrix:
   include:
     - rvm: 2.6
       env: RUBYOPT="--enable-frozen-string-literal"
-  # allow_failures:
-  #   - rvm: ruby-head
+      gemfile: gemfiles/rails_5.2.gemfile
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ gemfile:
 
 matrix:
   include:
-    - rvm: ruby-head
+    - rvm: 2.6
       env: RUBYOPT="--enable-frozen-string-literal"
   # allow_failures:
   #   - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  - ruby-head
+  - 2.6
 
 before_install:
   - gem install bundler

--- a/Appraisals
+++ b/Appraisals
@@ -8,6 +8,7 @@
 
 appraise 'rails-5.0' do
   gem 'rails', '>= 5.0.0', '< 5.1'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 appraise 'rails-5.1' do

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", ">= 5.0.0", "< 5.1"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/lib/awesome_print/ext/active_record.rb
+++ b/lib/awesome_print/ext/active_record.rb
@@ -55,7 +55,7 @@ module AwesomePrint
                  hash
                end
              end
-      "#{object} " << awesome_hash(data)
+      "#{object} #{awesome_hash(data)}"
     end
 
     # Format ActiveRecord class object.
@@ -95,7 +95,7 @@ module AwesomePrint
              end
 
       data.merge!({details: object.details, messages: object.messages})
-      "#{object} " << awesome_hash(data)
+      "#{object} #{awesome_hash(data)}"
     end
   end
 end

--- a/lib/awesome_print/formatters/array_formatter.rb
+++ b/lib/awesome_print/formatters/array_formatter.rb
@@ -31,7 +31,7 @@ module AwesomePrint
         if options[:multiline]
           multiline_array
         else
-          '[ ' << array.map { |item| inspector.awesome(item) }.join(', ') << ' ]'
+          "[ #{array.map { |item| inspector.awesome(item) }.join(', ')} ]"
         end
       end
 

--- a/lib/awesome_print/formatters/hash_formatter.rb
+++ b/lib/awesome_print/formatters/hash_formatter.rb
@@ -73,7 +73,7 @@ module AwesomePrint
 
         keys.map! do |key|
           plain_single_line do
-            [inspector.awesome(key), hash[key]]
+            [String.new(inspector.awesome(key)), hash[key]]
           end
         end
       end

--- a/lib/awesome_print/formatters/object_formatter.rb
+++ b/lib/awesome_print/formatters/object_formatter.rb
@@ -22,7 +22,7 @@ module AwesomePrint
             object.respond_to?(property) ? :reader : nil
           end
           if accessor
-            ["attr_#{accessor} :#{property}", var]
+            [String.new("attr_#{accessor} :#{property}"), var]
           else
             [var.to_s, var]
           end
@@ -60,7 +60,8 @@ module AwesomePrint
       end
 
       def awesome_instance
-        str = object.send(options[:class_name]).to_s
+        str = String.new
+        str << object.send(options[:class_name]).to_s
         str << ":0x%08x" % (object.__id__ * 2) if options[:object_id]
         str
       end

--- a/spec/formats_spec.rb
+++ b/spec/formats_spec.rb
@@ -492,7 +492,7 @@ EOS
   describe 'File' do
     it 'should display a file (plain)' do
       File.open(__FILE__, 'r') do |f|
-        expect(f.ai(plain: true)).to eq("#{f.inspect}\n" << `ls -alF #{f.path}`.chop)
+        expect(f.ai(plain: true)).to eq("#{f.inspect}\n#{`ls -alF #{f.path}`.chop}")
       end
     end
   end
@@ -501,7 +501,7 @@ EOS
   describe 'Dir' do
     it 'should display a direcory (plain)' do
       Dir.open(File.dirname(__FILE__)) do |d|
-        expect(d.ai(plain: true)).to eq("#{d.inspect}\n" << `ls -alF #{d.path}`.chop)
+        expect(d.ai(plain: true)).to eq("#{d.inspect}\n#{`ls -alF #{d.path}`.chop}")
       end
     end
   end
@@ -694,7 +694,7 @@ EOS
       class My < File; end
 
       my = File.new('/dev/null') rescue File.new('nul')
-      expect(my.ai(plain: true)).to eq("#{my.inspect}\n" << `ls -alF #{my.path}`.chop)
+      expect(my.ai(plain: true)).to eq("#{my.inspect}\n#{`ls -alF #{my.path}`.chop}")
     end
 
     it 'inherited from Dir should be displayed as Dir' do
@@ -702,7 +702,7 @@ EOS
 
       require 'tmpdir'
       my = My.new(Dir.tmpdir)
-      expect(my.ai(plain: true)).to eq("#{my.inspect}\n" << `ls -alF #{my.path}`.chop)
+      expect(my.ai(plain: true)).to eq("#{my.inspect}\n#{`ls -alF #{my.path}`.chop}")
     end
 
     it 'should handle a class that defines its own #send method' do


### PR DESCRIPTION
Rails 5.0 builds are failing, because the sqlite3 version being installed doesn't meet the requirements Rails 5.0 sets.

This PR locks the rails 5.0 gemfile to the same version requirement that rails 5.0 uses. It also switches to run against ruby 2.6 instead of head which is now past 2.6 and has several deprecations causing failures.