### PR TITLE
Update awsome_print.gemspec nokogiri dependency to resolve CVEs

### DIFF
--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'fakefs', '>= 0.2.1'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'nokogiri', '>= 1.6.5'
+  s.add_development_dependency 'nokogiri', '>= 1.10.4'
   # s.add_development_dependency 'simplecov'
   # s.add_development_dependency 'codeclimate-test-reporter'
 end


### PR DESCRIPTION
There are some CVEs known in older nokogiri versions that are causing this gem to fail vulnerability scans, specifically CVE-2016-4658, CVE-2019-11068, and CVE-2019-5477.