### PR TITLE
Fixes warning: Capturing the given block using Proc.new is deprecated; use `&block` instead (ruby 2.7.0 error)

### DIFF
--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -110,7 +110,7 @@ module AwesomePrint
       end
 
       def indented
-        inspector.increase_indentation(&Proc.new)
+        inspector.increase_indentation(&block)
       end
 
       def indent

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -63,7 +63,7 @@ module AwesomePrint
     end
 
     def increase_indentation
-      indentator.indent(&Proc.new)
+      indentator.indent(&block)
     end
 
     # Dispatcher that detects data nesting and invokes object-aware formatter.


### PR DESCRIPTION
* Fixes #382
* Fixes #354
* Fixes #373 