### PR TITLE
Added fix for warning: Capturing the given block using Proc.new is de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Adds support for ActiveModel::Errors [@dshinzie] - [#301]
   - removes use of `strip_heredoc` from specs as it's a rails dep [@kstephens] - [#303]
   - ArrayFormatter now returns arrays for has_many :through associations [@chadh13] - [#332]
+  - Fixes warning: Capturing the given block using Proc.new is deprecated; use `&block` instead [@yart] - [#385]
 
 ## 1.8.0
   - stat("$HOME/.aprc") once [@kstephens] - [#304]

--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -109,8 +109,8 @@ module AwesomePrint
         inspector.current_indentation
       end
 
-      def indented
-        inspector.increase_indentation(&Proc.new)
+      def indented(&block)
+        inspector.increase_indentation(&block)
       end
 
       def indent

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -62,8 +62,8 @@ module AwesomePrint
       indentator.indentation
     end
 
-    def increase_indentation
-      indentator.indent(&Proc.new)
+    def increase_indentation(&block)
+      indentator.indent(&block)
     end
 
     # Dispatcher that detects data nesting and invokes object-aware formatter.


### PR DESCRIPTION
…precated; use `&block` instead (ruby 2.7.x error)