### PR TITLE
Fix method signature after change in IRB

### DIFF
--- a/lib/awesome_print/custom_defaults.rb
+++ b/lib/awesome_print/custom_defaults.rb
@@ -27,7 +27,7 @@ module AwesomePrint
 
     def usual_rb
       IRB::Irb.class_eval do
-        def output_value
+        def output_value(*args)
           ap @context.last_value
         rescue NoMethodError
           puts "(Object doesn't support #ai)"


### PR DESCRIPTION
We override IRB::Irb::output_value in awesome_print/custom_defaults.rb.

IRB Introduced a default argument for this method in https://github.com/ruby/irb/commit/c5ea79d5cecea9cae6ad0c1f31703a98cd329431. When overriding this changed signature an ArgumentError is raised.

To fix, we capture any parameters. They are discarded anyway in our case.

Closes #389 