### PR TITLE
Updated nokogiri to fix vulnerability scan failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master (unreleased)
-  - 
+  - Update awsome_print.gemspec nokogiri dependency to resolve CVEs [@gvwirth]
 
 ## 1.9.0
   - Update method signature after change in IRB [@febeling]

--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'fakefs', '>= 0.2.1'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'nokogiri', '>= 1.6.5'
+  s.add_development_dependency 'nokogiri', '>= 1.10.4'
   # s.add_development_dependency 'simplecov'
   # s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'fakefs', '>= 0.2.1'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'nokogiri', '>= 1.10.4'
+  s.add_development_dependency 'nokogiri', '>= 1.11.0'
   # s.add_development_dependency 'simplecov'
   # s.add_development_dependency 'codeclimate-test-reporter'
 end


### PR DESCRIPTION
CVE-2016-4658, CVE-2019-11068 and CVE-2019-5477.
A dupe of PR370 (couldn't be merged because it failed TravisCI) - Thanks @gvwirth